### PR TITLE
Static cast type narrowing

### DIFF
--- a/wake.cpp
+++ b/wake.cpp
@@ -25,13 +25,13 @@ void WAKE_Base::GenKey(word32 k0, word32 k1, word32 k2, word32 k3)
 	CRYPTOPP_COMPILE_ASSERT(sizeof(x) == 4);
 	static unsigned int tt[10]= {
 		0x726a8f3b,								 // table
-		0xe69a3b5c,
-		0xd3c71fe5,
-		0xab3c73d2,
+		static_cast<int>(0xe69a3b5c),
+		static_cast<int>(0xd3c71fe5),
+		static_cast<int>(0xab3c73d2),
 		0x4d3a8eb3,
 		0x0396d6e8,
 		0x3d4c2f7a,
-		0x9ee27cf3, } ;
+		static_cast<int>(0x9ee27cf3), } ;
 	t[0] = k0;
 	t[1] = k1;
 	t[2] = k2;


### PR DESCRIPTION
Without the static casts, clang compiler fails to compile in C++11 mode with the following error

    wake.cpp:28:3: error: constant expression evaluates to 3868867420 which cannot be narrowed to type 'int' [-Wc++11-narrowing]
                    0xe69a3b5c,
                    ^~~~~~~~~~
    wake.cpp:28:3: note: insert an explicit cast to silence this issue
                    0xe69a3b5c,
                    ^~~~~~~~~~
                    static_cast<int>( )
    wake.cpp:29:3: error: constant expression evaluates to 3553042405 which cannot be narrowed to type 'int' [-Wc++11-narrowing]
                    0xd3c71fe5,
                    ^~~~~~~~~~
    wake.cpp:29:3: note: insert an explicit cast to silence this issue
                    0xd3c71fe5,
                    ^~~~~~~~~~
                    static_cast<int>( )
    wake.cpp:30:3: error: constant expression evaluates to 2872865746 which cannot be narrowed to type 'int' [-Wc++11-narrowing]
                    0xab3c73d2,
                    ^~~~~~~~~~
    wake.cpp:30:3: note: insert an explicit cast to silence this issue
                    0xab3c73d2,
                    ^~~~~~~~~~
                    static_cast<int>( )
    wake.cpp:34:3: error: constant expression evaluates to 2665643251 which cannot be narrowed to type 'int' [-Wc++11-narrowing]
                    0x9ee27cf3, } ;
                    ^~~~~~~~~~
    wake.cpp:34:3: note: insert an explicit cast to silence this issue
                    0x9ee27cf3, } ;
                    ^~~~~~~~~~
                    static_cast<int>( )
    4 errors generated.