### PR TITLE
Fixes the warning on IntToString about comparison of unsigned and sig…

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -6,6 +6,8 @@
 #include "stdcpp.h"
 #include "trap.h"
 
+#include <limits>
+
 #ifdef _MSC_VER
 	#if _MSC_VER >= 1400
 		// VC2005 workaround: disable declarations that conflict with winnt.h
@@ -69,6 +71,16 @@ template <bool b>
 struct CompileAssert
 {
 	static char dummy[2*b-1];
+};
+
+// Checks signed input to be negative or positive.
+template < typename T, bool sig> struct negative{
+  bool operator()(const T &x){ return x < 0; }
+};
+
+// Unsigned input won't be checked, this avoids the compiler warning when unsigned int (or long unsigned int) is used.
+template < typename T> struct negative<T,false>{
+  bool operator()(const T &x){ return false; }
 };
 
 // __attribute__ ((unused)) will help silence the "unused variable warnings. Its available
@@ -532,8 +544,7 @@ std::string IntToString(T a, unsigned int base = 10)
 	if (a == 0)
 		return "0";
 	bool negate = false;
-	if (a < 0)
-	{
+	if (negative<T, std::numeric_limits<T>::is_signed>()(a)) {
 		negate = true;
 		a = 0-a;	// VC .NET does not like -a
 	}


### PR DESCRIPTION
This issue is mentioned somewhere else, but I found it while compiling a small program with crypto++; I'm using boost::uint32_t and boost::uint64_t with IntToString() method, in which case the internal comparison (a < 0) makes no sense.

The patch I'm pulling fixes this warning as the template checks the signedness of the input value; if the value is signed, the right comparison function is used, and when the input is unsigned, then returns false.

Haven't tried on Windows compilers, it works fine with gcc (since 4.4) and MacOSX.