### PR TITLE
Updated SHA3 padding to NIST final FIPS 202 spec

### DIFF
--- a/sha3.cpp
+++ b/sha3.cpp
@@ -274,7 +274,7 @@ void SHA3::Restart()
 void SHA3::TruncatedFinal(byte *hash, size_t size)
 {
 	ThrowIfInvalidTruncatedSize(size);
-	m_state.BytePtr()[m_counter] ^= 1;
+	m_state.BytePtr()[m_counter] ^= 0x06;
 	m_state.BytePtr()[r()-1] ^= 0x80;
 	KeccakF1600(m_state);
 	memcpy(hash, m_state, size);


### PR DESCRIPTION
Updated SHA3 padding to the final NIST spec (FIPS 202).

http://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf