### PR TITLE
CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,185 @@
+cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+project(cryptopp VERSION 5.6.3)
+
+include(GNUInstallDirs)
+include(TestBigEndian)
+include(CheckCXXSymbolExists)
+
+#============================================================================
+# Settable options
+#============================================================================
+
+option(BUILD_TESTING "Build library tests" ON)
+option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" OFF)
+
+option(DISABLE_ASM "Disable ASM" OFF)
+option(DISABLE_SSSE3 "Disable SSSE3" OFF)
+option(DISABLE_AESNI "Disable AES-NI" OFF)
+
+#============================================================================
+# Internal compiler options
+#============================================================================
+
+set(LIB_VER ${cryptopp_VERSION_MAJOR}${cryptopp_VERSION_MINOR}${cryptopp_VERSION_PATCH})
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+	add_definitions(-wd68 -wd186 -wd279 -wd327 -wd161 -wd3180)
+endif()
+
+# Endianess
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+if(IS_BIG_ENDIAN)
+	add_definitions(-DIS_BIG_ENDIAN)
+endif()
+
+if(DISABLE_ASM)
+	add_definitions(-DCRYPTOPP_DISABLE_ASM)
+endif()
+if(DISABLE_SSSE3)
+	add_definitions(-DCRYPTOPP_DISABLE_SSSE3)
+endif()
+if(DISABLE_AESNI)
+	add_definitions(-DCRYPTOPP_DISABLE_AESNI)
+endif()
+
+#============================================================================
+# Sources & headers
+#============================================================================
+
+# Library headers
+file(GLOB cryptopp_HEADERS *.h)
+
+# Test sources
+file(GLOB cryptopp_SOURCES_TEST bench.cpp bench2.cpp test.cpp validat1.cpp validat2.cpp validat3.cpp adhoc.cpp datatest.cpp regtest.cpp fipsalgt.cpp dlltest.cpp fipstest.cpp)
+
+# Library sources
+file(GLOB cryptopp_SOURCES *.cpp)
+list(REMOVE_ITEM cryptopp_SOURCES
+		${CMAKE_CURRENT_SOURCE_DIR}/cryptlib.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/cpu.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/pch.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/simple.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/winpipes.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/cryptlib_bds.cpp
+		${cryptopp_SOURCES_TEST}
+		)
+set(cryptopp_SOURCES
+		${CMAKE_CURRENT_SOURCE_DIR}/cryptlib.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/cpu.cpp
+		${cryptopp_SOURCES}
+		)
+
+if(MINGW)
+	list(APPEND cryptopp_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/winpipes.cpp)
+endif()
+
+#============================================================================
+# Compile targets
+#============================================================================
+add_library(cryptopp-object OBJECT ${cryptopp_SOURCES})
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# Enables -fPIC on all 64-bit platforms
+	set_target_properties(cryptopp-object PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+endif()
+
+add_library(cryptopp-static STATIC $<TARGET_OBJECTS:cryptopp-object>)
+add_library(cryptopp-shared SHARED $<TARGET_OBJECTS:cryptopp-object>)
+
+target_include_directories(cryptopp-shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/cryptopp>)
+target_include_directories(cryptopp-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/cryptopp>)
+
+if(NOT MSVC)
+	set(COMPAT_VERSION ${cryptopp_VERSION_MAJOR}.${cryptopp_VERSION_MINOR})
+
+	set_target_properties(cryptopp-static
+			PROPERTIES
+			OUTPUT_NAME cryptopp)
+	set_target_properties(cryptopp-shared
+			PROPERTIES
+			SOVERSION ${COMPAT_VERSION}
+			OUTPUT_NAME cryptopp)
+endif()
+
+#============================================================================
+# Third-party libraries
+#============================================================================
+if(WIN32)
+	target_link_libraries(cryptopp-static ws2_32)
+	target_link_libraries(cryptopp-shared ws2_32)
+endif()
+
+find_package(Threads)
+target_link_libraries(cryptopp-static ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(cryptopp-shared ${CMAKE_THREAD_LIBS_INIT})
+
+#============================================================================
+# Tests
+#============================================================================
+enable_testing()
+if(BUILD_TESTING)
+	add_library(cryptest-object OBJECT ${cryptopp_SOURCES_TEST})
+
+	add_executable(cryptest $<TARGET_OBJECTS:cryptest-object>)
+	target_link_libraries(cryptest cryptopp-static)
+
+	file(COPY ${CMAKE_SOURCE_DIR}/TestData DESTINATION ${PROJECT_BINARY_DIR})
+	file(COPY ${CMAKE_SOURCE_DIR}/TestVectors DESTINATION ${PROJECT_BINARY_DIR})
+
+	add_test(NAME cryptest COMMAND $<TARGET_FILE:cryptest> v)
+endif()
+
+#============================================================================
+# Doxygen documentation
+#============================================================================
+if(BUILD_DOCUMENTATION)
+	find_package(Doxygen REQUIRED)
+
+	set(in_source_DOCS_DIR "${CMAKE_SOURCE_DIR}/html-docs")
+	set(out_source_DOCS_DIR "${PROJECT_BINARY_DIR}/html-docs")
+
+	add_custom_target(docs ALL
+			COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile -d CRYPTOPP_DOXYGEN_PROCESSING
+			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			SOURCES ${CMAKE_SOURCE_DIR}/Doxyfile
+			)
+
+	if(NOT ${in_source_DOCS_DIR} STREQUAL ${out_source_DOCS_DIR})
+		add_custom_command(
+				TARGET docs POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_directory "${in_source_DOCS_DIR}" "${out_source_DOCS_DIR}"
+				COMMAND ${CMAKE_COMMAND} -E remove_directory "${in_source_DOCS_DIR}"
+		)
+	endif()
+endif()
+
+#============================================================================
+# Install
+#============================================================================
+set(export_name "cryptopp-targets")
+
+# Runtime package
+install(TARGETS cryptopp-shared EXPORT ${export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# Development package
+install(TARGETS cryptopp-static EXPORT ${export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES ${cryptopp_HEADERS} DESTINATION include/cryptopp)
+
+# CMake Package
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake" COMPATIBILITY SameMajorVersion)
+install(FILES cryptopp-config.cmake ${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake DESTINATION "lib/cmake/cryptopp")
+install(EXPORT ${export_name} DESTINATION "lib/cmake/cryptopp")
+
+# Tests
+if(BUILD_TESTING)
+	install(TARGETS cryptest DESTINATION ${CMAKE_INSTALL_BINDIR})
+	install(DIRECTORY ${CMAKE_SOURCE_DIR}/TestData DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cryptopp)
+	install(DIRECTORY ${CMAKE_SOURCE_DIR}/TestVectors DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/cryptopp)
+endif()
+
+
+# Documentation
+if(BUILD_DOCUMENTATION)
+	install(DIRECTORY "${out_source_DOCS_DIR}" DESTINATION ${CMAKE_INSTALL_DOCDIR})
+endif()

--- a/cryptopp-config.cmake
+++ b/cryptopp-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/cryptopp-targets.cmake")


### PR DESCRIPTION
Hello,
I have added CMake build, as mentioned in #73.

Building static+shared library.
---------------------------------------
- Honors object linking order, to contend [Static Initialization Order Fiasco](https://cryptopp.com/wiki/Static_Initialization_Order_Fiasco).  
- Forces adding -fPIC to all 64-bit architectures, such as amd64 and aarch64. For 32-bit architectures behaviour is controlled using `-DCMAKE_POSITION_INDEPENDENT_CODE=ON/OFF`
- Warns if `CRYPTOPP_NO_UNALIGNED_DATA_ACCESS` or `CRYPTOPP_INIT_PRIORITY` not defined in config.h
- Detects and sets endianess.
- `DISABLE_ASM`, `DISABLE_SSSE3` and `DISABLE_AESNI` are **not** set automatically right now (using compiler detection), so they are made as CMake options.
- Links to ws2_32 on Windows and to pthread on Linux.
- SONAME support for Linux (version_major.version_minor)

Building tests (cryptest).
--------------------------------
The test can be built and performes, if `BUILD_TESTING` is set to `ON` (default).
Command: `make test`

Building documentation using Doxygen.
-----------------------------------------------------
I had to create a new file, `Doxyfile.in`, as Doxygen can't make out-of-source builds. This is *the right way* to do this in CMake, but we may have to maintain it :confused:
The build yields CryptoPPRef.zip, containing all documentation, generated by Doxygen (just like GNUmakefile build).

Install.
--------
On `make install` CMake installs a package, that could be used by other projects, using `FindPackage(cryptopp)`, eliminating the need of `FindCryptoPP.cmake` module.
Also, `make install` just installs the libraries in `lib`, includes in `include`, and documentation in `share/doc`, honoring FHS on Linux.

Also, I've added a working `.travis.yml` file for [Travis-CI](https://travis-ci.org), if you ever want to use it. 