### PR TITLE
Makefile improvements

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -39,7 +39,7 @@ MACPORTS_COMPILER := $(shell $(CXX) --version 2>&1 | $(EGREP) -i -c "macports")
 
 # Default prefix for make install
 ifeq ($(PREFIX),)
-PREFIX = /usr
+PREFIX = /usr/local
 endif
 
 ifeq ($(CXX),gcc)	# for some reason CXX is gcc on cygwin 1.1.4

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -354,31 +354,31 @@ endif
 
 .PHONY: install
 install:
-	$(MKDIR) -p $(PREFIX)/include/cryptopp $(PREFIX)/lib $(PREFIX)/bin
-	-$(CP) *.h $(PREFIX)/include/cryptopp
-	-$(CHMOD) 755 $(PREFIX)/include/cryptopp
-	-$(CHMOD) 644 $(PREFIX)/include/cryptopp/*.h
-	-$(CP) libcryptopp.a $(PREFIX)/lib
-	-$(CHMOD) 644 $(PREFIX)/lib/libcryptopp.a
-	-$(CP) cryptest.exe $(PREFIX)/bin
-	-$(CHMOD) 755 $(PREFIX)/bin/cryptest.exe
+	$(MKDIR) -p $(DESTDIR)$(PREFIX)/include/cryptopp $(DESTDIR)$(PREFIX)/lib $(DESTDIR)$(PREFIX)/bin
+	-$(CP) *.h $(DESTDIR)$(PREFIX)/include/cryptopp
+	-$(CHMOD) 755 $(DESTDIR)$(PREFIX)/include/cryptopp
+	-$(CHMOD) 644 $(DESTDIR)$(PREFIX)/include/cryptopp/*.h
+	-$(CP) libcryptopp.a $(DESTDIR)$(PREFIX)/lib
+	-$(CHMOD) 644 $(DESTDIR)$(PREFIX)/lib/libcryptopp.a
+	-$(CP) cryptest.exe $(DESTDIR)$(PREFIX)/bin
+	-$(CHMOD) 755 $(DESTDIR)$(PREFIX)/bin/cryptest.exe
 ifneq ($(IS_DARWIN),0)
-	-$(CP) libcryptopp.dylib $(PREFIX)/lib
-	-$(CHMOD) 755 $(PREFIX)/lib/libcryptopp.dylib
+	-$(CP) libcryptopp.dylib $(DESTDIR)$(PREFIX)/lib
+	-$(CHMOD) 755 $(DESTDIR)$(PREFIX)/lib/libcryptopp.dylib
 else
-	-$(CP) libcryptopp.so $(PREFIX)/lib
-	-$(CHMOD) 755 $(PREFIX)/lib/libcryptopp.so
+	-$(CP) libcryptopp.so $(DESTDIR)$(PREFIX)/lib
+	-$(CHMOD) 755 $(DESTDIR)$(PREFIX)/lib/libcryptopp.so
 endif
 
 .PHONY: remove uninstall
 remove uninstall:
-	-$(RM) -r $(PREFIX)/include/cryptopp
-	-$(RM) $(PREFIX)/lib/libcryptopp.a
-	-$(RM) $(PREFIX)/bin/cryptest.exe
+	-$(RM) -r $(DESTDIR)$(PREFIX)/include/cryptopp
+	-$(RM) $(DESTDIR)$(PREFIX)/lib/libcryptopp.a
+	-$(RM) $(DESTDIR)$(PREFIX)/bin/cryptest.exe
 ifneq ($(IS_DARWIN),0)
-	-$(RM) $(PREFIX)/lib/libcryptopp.dylib
+	-$(RM) $(DESTDIR)$(PREFIX)/lib/libcryptopp.dylib
 else
-	-$(RM) $(PREFIX)/lib/libcryptopp.so
+	-$(RM) $(DESTDIR)$(PREFIX)/lib/libcryptopp.so
 endif
 
 libcryptopp.a: public_service | $(LIBOBJS)


### PR DESCRIPTION
First commit was discussed in issue #80 and is part of the mailing list discussion (https://groups.google.com/forum/#!topic/cryptopp-users/_pbRVo7T_OM)

The second commit adds support for DESTDIR, which complements PREFIX variable, but only during the installation phase.  For the current makefile it makes no difference, but can be needed after #80 is merged.