### PR TITLE
Added CRYPTOPP_DATA_DIR option in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentati
 option(DISABLE_ASM "Disable ASM" OFF)
 option(DISABLE_SSSE3 "Disable SSSE3" OFF)
 option(DISABLE_AESNI "Disable AES-NI" OFF)
+set(CRYPTOPP_DATA_DIR "" CACHE PATH "Crypto++ test data directory")
 
 #============================================================================
 # Internal compiler options
@@ -40,6 +41,9 @@ if(DISABLE_SSSE3)
 endif()
 if(DISABLE_AESNI)
 	add_definitions(-DCRYPTOPP_DISABLE_AESNI)
+endif()
+if(NOT CRYPTOPP_DATA_DIR STREQUAL "")
+	add_definitions(-DCRYPTOPP_DATA_DIR=${CRYPTOPP_DATA_DIR})
 endif()
 
 #============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
-project(cryptopp VERSION 5.6.3)
+cmake_minimum_required(VERSION 2.8.5 FATAL_ERROR)
+
+project(cryptopp)
+
+set(cryptopp_VERSION_MAJOR 5)
+set(cryptopp_VERSION_MINOR 6)
+set(cryptopp_VERSION_PATCH 3)
 
 include(GNUInstallDirs)
 include(TestBigEndian)
@@ -171,7 +176,7 @@ install(FILES ${cryptopp_HEADERS} DESTINATION include/cryptopp)
 
 # CMake Package
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file("${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake" COMPATIBILITY SameMajorVersion)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake" VERSION ${cryptopp_VERSION_MAJOR}.${cryptopp_VERSION_MINOR}.${cryptopp_VERSION_PATCH} COMPATIBILITY SameMajorVersion)
 install(FILES cryptopp-config.cmake ${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake DESTINATION "lib/cmake/cryptopp")
 install(EXPORT ${export_name} DESTINATION "lib/cmake/cryptopp")
 


### PR DESCRIPTION
This isn't really necessary, as this option can be set with `cmake -DCMAKE_CXX_FLAGS="-DCRYPTOPP_DATA_DIR=\"/usr/lib/...\""`
But now you can do `cmake -DCRYPTOPP_DATA_DIR=\"/usr/lib/...\"`, which is simpler.