### PR TITLE
Fix problem, pull request #65 comment 168191115

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -470,8 +470,10 @@ libcryptopp.a: $(LIBOBJS) | public_service
 	$(AR) $(ARFLAGS) $@ $(LIBOBJS)
 	$(RANLIB) $@
 
+ifeq ($(HAS_SOLIB_VERSION),1)
 .PHONY: libcryptopp.so
-libcryptopp.so: libcryptopp$(SOLIB_VERSION_SUFFIX)
+libcryptopp.so: libcryptopp.so$(SOLIB_VERSION_SUFFIX)
+endif
 
 libcryptopp.so$(SOLIB_VERSION_SUFFIX): $(LIBOBJS) | public_service
 	$(CXX) -shared $(SOLIB_FLAGS) -o $@ $(CXXFLAGS) $(GOLD_OPTION) $(LIBOBJS) $(LDLIBS)

--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -198,8 +198,10 @@ libcryptopp.a: $(LIBOBJS)
 	$(AR) $(ARFLAGS) $@ $(LIBOBJS)
 	$(RANLIB) $@
 
+ifeq ($(HAS_SOLIB_VERSION),1)
 .PHONY: libcryptopp.so
 libcryptopp.so: libcryptopp.so$(SOLIB_VERSION_SUFFIX)
+endif
 
 libcryptopp.so$(SOLIB_VERSION_SUFFIX): $(LIBOBJS)
 	$(CXX) -shared $(SOLIB_FLAGS) -o $@ $(CXXFLAGS) -Wl,--exclude-libs,ALL $(LIBOBJS) $(LDLIBS)


### PR DESCRIPTION
Fixed the problem with the libcryptopp.so target's right-hand side missing the .so. Also fixed it so we don't have that target when HAVE_SOLIB_VERSION is 0 and the libcryptopp.so$(SOLIB_VERSION_SUFFIX) target will translate to plain libcryptopp.so.