### PR TITLE
Fixes a compiler error with C++Builder XE6

### DIFF
--- a/pkcspad.h
+++ b/pkcspad.h
@@ -76,7 +76,7 @@ public:
 		{
 			static HashIdentifier Lookup()
 			{
-				return HashIdentifier(PKCS_DigestDecoration<H>::decoration, PKCS_DigestDecoration<H>::length);
+				return HashIdentifier(PKCS_DigestDecoration<H>::decoration, (size_t)PKCS_DigestDecoration<H>::length);
 			}
 		};
 	};


### PR DESCRIPTION
This is the generated error with CLANG 64-bit:
[bcc64 Error] pkcspad.h(79): call to constructor of 'HashIdentifier' (aka 'pair<const byte *, size_t>') is ambiguous

Casting the second parameter as size_t will fix the problem. This fix is not required in C++Builder XE7 and XE8, it must have been fixed.