### PR TITLE
With C++Builder we need to include stdlib.h to use wcstombs

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -1,4 +1,4 @@
-﻿// misc.h - written and placed in the public domain by Wei Dai
+// misc.h - written and placed in the public domain by Wei Dai
 
 //! \file misc.h
 //! \brief Utility functions for the Crypto++ library.

--- a/misc.h
+++ b/misc.h
@@ -1,4 +1,4 @@
-// misc.h - written and placed in the public domain by Wei Dai
+﻿// misc.h - written and placed in the public domain by Wei Dai
 
 //! \file misc.h
 //! \brief Utility functions for the Crypto++ library.
@@ -51,6 +51,7 @@
 
 #ifdef __BORLANDC__
 #include <mem.h>
+#include <stdlib.h>
 #endif
 
 #if defined(__GNUC__) && defined(__linux__)


### PR DESCRIPTION
wcstombs was supported in C++Builder 2010 : http://docwiki.embarcadero.com/RADStudio/2010/en/Wcstombs