### PR TITLE
Remove unwanted assert

### DIFF
--- a/asn.cpp
+++ b/asn.cpp
@@ -405,14 +405,14 @@ void BERGeneralDecoder::Init(byte asnTag)
 
 BERGeneralDecoder::~BERGeneralDecoder()
 {
-	try	// avoid throwing in constructor
+	try	// avoid throwing in destructor
 	{
 		if (!m_finished)
 			MessageEnd();
 	}
 	catch (const Exception&)
 	{
-		assert(0);
+		// assert(0);
 	}
 }
 


### PR DESCRIPTION
When decoding a key, Crypto++ may throw an exception (if there is a format error).
I want to be able to catch exception, but it is not possible in debug mode. Here how it goes:

* An exception is thrown during the decoding process
* Before it can be caught, the ```BERGeneralDecoder``` destructor is called.
* The destructor calls ```MessageEnd()``` which in turn throw an exception
* As throwing exception in destructor is bad, the exception get caught and an ```assert(0)``` is called

So in debug mode, each time there is a decoding error, the ```assert(0)``` gets called, and the program stops.

To fix this I just removed the ```assert(0)``` in the catch block.
(This was tested with visual studio 2015)



