### PR TITLE
Fixed linker error when using VS2015 /MD

### DIFF
--- a/fipstest.cpp
+++ b/fipstest.cpp
@@ -21,7 +21,11 @@
 #else
 #define _CRT_DEBUGGER_HOOK __crt_debugger_hook
 #endif
+#if _MSC_VER < 1900
 extern "C" {_CRTIMP void __cdecl _CRT_DEBUGGER_HOOK(int);}
+#else
+extern "C" {void __cdecl _CRT_DEBUGGER_HOOK(int); }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Without this change links under Visual Studio 2015 using the `/MDd` switch ("multithreaded debug dll" c-runtime) fail with a `LNK2005: __crt_debugger_hook already defined in msvcrtd.lib(utility_desktop.obj)`
error.