### PR TITLE
Fix Visual Studio compilation with _HAS_EXCEPTIONS=0

### DIFF
--- a/stdcpp.h
+++ b/stdcpp.h
@@ -6,13 +6,6 @@
 #include <intrin.h>
 #endif
 
-#ifdef _MSC_VER
-// Workaround for: https://connect.microsoft.com/VisualStudio/feedback/details/1600701/type-info-does-not-compile-with-has-exceptions-0
-namespace std {
-  using ::type_info;
-}
-#endif
-
 #include <string>
 #include <memory>
 #include <exception>
@@ -26,6 +19,13 @@ namespace std {
 #include <list>
 #include <map>
 #include <new>
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900) && defined(_HAS_EXCEPTIONS) && (_HAS_EXCEPTIONS == 0)
+// Workaround for: https://connect.microsoft.com/VisualStudio/feedback/details/1600701/type-info-does-not-compile-with-has-exceptions-0
+namespace std {
+  using ::type_info;
+}
+#endif
 
 #if _MSC_VER >= 1600
 // for make_unchecked_array_iterator

--- a/stdcpp.h
+++ b/stdcpp.h
@@ -6,6 +6,13 @@
 #include <intrin.h>
 #endif
 
+#ifdef _MSC_VER
+// Workaround for: https://connect.microsoft.com/VisualStudio/feedback/details/1600701/type-info-does-not-compile-with-has-exceptions-0
+namespace std {
+  using ::type_info;
+}
+#endif
+
 #include <string>
 #include <memory>
 #include <exception>


### PR DESCRIPTION
Bug information: https://connect.microsoft.com/VisualStudio/feedback/details/1600701/type-info-does-not-compile-with-has-exceptions-0

For example:
```
C:\Work\github\cryptopp>cl /c /Tp cryptlib.h /Focryptlib.h.obj /D_HAS_EXCEPTIONS=0
Microsoft (R) C/C++ Optimizing Compiler Version 18.00.31101 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

cryptlib.h
c:\work\github\cryptopp\cryptlib.h(292) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(298) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(302) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(305) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(306) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(392) : error C2039: 'type_info' : is not a member of 'std'
c:\work\github\cryptopp\cryptlib.h(437) : error C2039: 'type_info' : is not a member of 'std'
```