### PR TITLE
replaced special character

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -439,7 +439,7 @@ template <class T1, class T2> inline const T1 UnsignedMin(const T1& a, const T2&
 		return (T1)b < a ? (T1)b : a;
 }
 
-//! \brief Tests whether a conversion from → to is safe to perform
+//! \brief Tests whether a conversion from -> to is safe to perform
 //! \param from the first value
 //! \param to the second value
 //! \returns true if its safe to convert from into to, false otherwise.

--- a/smartptr.h
+++ b/smartptr.h
@@ -31,7 +31,7 @@ public:
 };
 
 //! \class member_ptr
-//! \brief Pointer that overloads operator→
+//! \brief Pointer that overloads operator ->
 //! \tparam T class or type
 //! \details member_ptr is used frequently in the library to avoid the issues related to
 //!   std::auto_ptr in C++11 (deprecated) and std::unique_ptr in C++03 (non-existent).


### PR DESCRIPTION
replaced special character which caused visual studio warning C4819 with other system encoding