### PR TITLE
Fix _WIN32_WINNT for Windows Store Apps >= 10.*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ if(NOT CRYPTOPP_DATA_DIR STREQUAL "")
 endif()
 
 if(WINDOWS_STORE OR WINDOWS_PHONE)
+	if("${CMAKE_SYSTEM_VERSION}" MATCHES "10\\.0.*")
+		SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /D\"_WIN32_WINNT=0x0A00\"" )
+	endif()
 	SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /FI\"winapifamily.h\"" )
 endif()
 #============================================================================


### PR DESCRIPTION
If use CMake for WindowsStore 10.0, _WIN32_WINNT not set and it compiles library without CNG API