### PR TITLE
Fixed multiple CMake issues and added complete support for CMake 2.8.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(cryptopp_VERSION_PATCH 3)
 
 include(GNUInstallDirs)
 include(TestBigEndian)
-include(CheckCXXSymbolExists)
 
 #============================================================================
 # Settable options
@@ -124,31 +123,67 @@ endif()
 #============================================================================
 # Compile targets
 #============================================================================
-add_library(cryptopp-object OBJECT ${cryptopp_SOURCES})
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	# Enables -fPIC on all 64-bit platforms
-	set_target_properties(cryptopp-object PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+# Set global includes BEFORE adding any targets for legacy CMake versions
+if(CMAKE_VERSION VERSION_LESS 2.8.12)
+	include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+endif()
+
+if(NOT CMAKE_VERSION VERSION_LESS 2.8.8)
+	add_library(cryptopp-object OBJECT ${cryptopp_SOURCES})
 endif()
 
 if (BUILD_STATIC)
-	add_library(cryptopp-static STATIC $<TARGET_OBJECTS:cryptopp-object>)
+	if(NOT CMAKE_VERSION VERSION_LESS 2.8.8)
+		add_library(cryptopp-static STATIC $<TARGET_OBJECTS:cryptopp-object>)
+	else()
+		add_library(cryptopp-static STATIC ${cryptopp_SOURCES})
+	endif()
+
 	if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
 		target_include_directories(cryptopp-static PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/cryptopp>)
-	else()
-		include_directories("${ROOT_SOURCE_DIR}")
 	endif()
 endif()
 
 if (BUILD_SHARED)
-	add_library(cryptopp-shared SHARED $<TARGET_OBJECTS:cryptopp-object>)
+	if(NOT CMAKE_VERSION VERSION_LESS 2.8.8)
+		add_library(cryptopp-shared SHARED $<TARGET_OBJECTS:cryptopp-object>)
+	else()
+		add_library(cryptopp-shared SHARED ${cryptopp_SOURCES})
+	endif()
+
 	if (NOT CMAKE_VERSION VERSION_LESS 2.8.12)
 		target_include_directories(cryptopp-shared PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/cryptopp>)
-	else()
-		include_directories("${ROOT_SOURCE_DIR}")
 	endif()
 endif()
 
+# Set PIC
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+	# Enables -fPIC on all 64-bit platforms
+	if(NOT CMAKE_VERSION VERSION_LESS 2.8.9)	# POSITION_INDEPENDENT_CODE support
+		set_target_properties(cryptopp-object PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+	elseif(NOT CMAKE_VERSION VERSION_LESS 2.8.8)	# Object library support
+		get_target_property(flags_old cryptopp-object COMPILE_FLAGS)
+		set_target_properties(cryptopp-object PROPERTIES COMPILE_FLAGS "${flags_old} -fPIC")
+	else()
+		if (BUILD_STATIC)
+			get_target_property(flags_old_static cryptopp-static COMPILE_FLAGS)
+			if(NOT flags_old_static)
+				set(flags_old_static "")
+			endif()
+			set_target_properties(cryptopp-static PROPERTIES COMPILE_FLAGS "${flags_old_static} -fPIC")
+		endif()
+		if (BUILD_SHARED)
+			get_target_property(flags_old_shared cryptopp-shared COMPILE_FLAGS)
+			if(NOT flags_old_shared)
+				set(flags_old_shared "")
+			endif()
+			set_target_properties(cryptopp-shared PROPERTIES COMPILE_FLAGS "${flags_old_shared} -fPIC")
+		endif()
+	endif()
+endif()
+
+# Set filenames for targets to be "cryptopp"
 if(NOT MSVC)
 	set(COMPAT_VERSION ${cryptopp_VERSION_MAJOR}.${cryptopp_VERSION_MINOR})
 
@@ -163,6 +198,16 @@ if(NOT MSVC)
 				SOVERSION ${COMPAT_VERSION}
 				OUTPUT_NAME cryptopp)
 	endif()
+endif()
+
+# Targets, compatible with Crypto++ GNUMakefile
+if (BUILD_STATIC)
+	add_custom_target(static)
+	add_dependencies(static cryptopp-static)
+endif()
+if (BUILD_SHARED)
+	add_custom_target(dynamic)
+	add_dependencies(dynamic cryptopp-shared)
 endif()
 
 #============================================================================
@@ -190,15 +235,15 @@ endif()
 #============================================================================
 enable_testing()
 if(BUILD_TESTING)
-	add_library(cryptest-object OBJECT ${cryptopp_SOURCES_TEST})
-
-	add_executable(cryptest $<TARGET_OBJECTS:cryptest-object>)
+	add_executable(cryptest ${cryptopp_SOURCES_TEST})
 	target_link_libraries(cryptest cryptopp-static)
 
 	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/TestData DESTINATION ${PROJECT_BINARY_DIR})
 	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/TestVectors DESTINATION ${PROJECT_BINARY_DIR})
 
+	add_test(NAME build_cryptest COMMAND "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target cryptest)
 	add_test(NAME cryptest COMMAND $<TARGET_FILE:cryptest> v)
+	set_tests_properties(cryptest PROPERTIES DEPENDS build_cryptest)
 endif()
 
 #============================================================================
@@ -242,10 +287,12 @@ endif()
 install(FILES ${cryptopp_HEADERS} DESTINATION include/cryptopp)
 
 # CMake Package
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file("${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake" VERSION ${cryptopp_VERSION_MAJOR}.${cryptopp_VERSION_MINOR}.${cryptopp_VERSION_PATCH} COMPATIBILITY SameMajorVersion)
-install(FILES cryptopp-config.cmake ${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake DESTINATION "lib/cmake/cryptopp")
-install(EXPORT ${export_name} DESTINATION "lib/cmake/cryptopp")
+if(NOT CMAKE_VERSION VERSION_LESS 2.8.8)	# CMakePackageConfigHelpers is supported from 2.8.8
+	include(CMakePackageConfigHelpers)
+	write_basic_package_version_file("${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake" VERSION ${cryptopp_VERSION_MAJOR}.${cryptopp_VERSION_MINOR}.${cryptopp_VERSION_PATCH} COMPATIBILITY SameMajorVersion)
+	install(FILES cryptopp-config.cmake ${PROJECT_BINARY_DIR}/cryptopp-config-version.cmake DESTINATION "lib/cmake/cryptopp")
+	install(EXPORT ${export_name} DESTINATION "lib/cmake/cryptopp")
+endif()
 
 # Tests
 if(BUILD_TESTING)


### PR DESCRIPTION
Fixed issues:
Fixed #192
Fixed #198
Fixed #199

Also, added complete support for CMake 2.8.5 and tested it on Ubuntu 12.04.
```
vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 12.04.5 LTS
Release:        12.04
Codename:       precise

vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$ ../../cmake-2.8.5/bin/cmake --version
cmake version 2.8.5

vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$ g++ --version
g++ (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3
Copyright (C) 2011 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$ ../../cmake-2.8.5/bin/cmake ../../cryptopp/
-- The C compiler identification is GNU
-- The CXX compiler identification is GNU
-- Check for working C compiler: /usr/bin/gcc
-- Check for working C compiler: /usr/bin/gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check if the system is big endian
-- Searching 16 bit integer
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of unsigned short
-- Check size of unsigned short - done
-- Using unsigned short
-- Check if the system is big endian - little endian
-- Looking for include files CMAKE_HAVE_PTHREAD_H
-- Looking for include files CMAKE_HAVE_PTHREAD_H - found
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE 
-- Configuring done
-- Generating done
-- Build files have been written to: /vagrant/build/cryptopp-precise

vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$ make static dynamic test
... Skipped the output, it is really big and not interesting, no errors here ...
[100%] Built target cryptopp-static
[100%] Built target static
... Skipped the output, it is really big and not interesting, no errors here ...
[100%] Built target cryptopp-shared
[100%] Built target dynamic
... Skipped the output, it is really big and not interesting, no errors here ...
Running tests...
Test project /vagrant/build/cryptopp-precise
    Start 1: build_cryptest
1/2 Test #1: build_cryptest ...................   Passed   47.68 sec
    Start 2: cryptest
2/2 Test #2: cryptest .........................   Passed    6.09 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  53.81 sec

vagrant@vagrant-ubuntu-precise-64:/vagrant/build/cryptopp-precise$
```