### PR TITLE
CMake cryptest binary is now named "cryptest.exe" on all platforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,15 @@ if(BUILD_TESTING)
 	add_executable(cryptest ${cryptopp_SOURCES_TEST})
 	target_link_libraries(cryptest cryptopp-static)
 
+	# Setting "cryptest" binary name to "cryptest.exe"
+	if(NOT WIN32)
+		set_target_properties(cryptest PROPERTIES OUTPUT_NAME cryptest.exe)
+	endif()
+	if(NOT TARGET cryptest.exe)
+		add_custom_target(cryptest.exe)
+		add_dependencies(cryptest.exe cryptest)
+	endif()
+
 	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/TestData DESTINATION ${PROJECT_BINARY_DIR})
 	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/TestVectors DESTINATION ${PROJECT_BINARY_DIR})
 


### PR DESCRIPTION
As a result of our discussion, I am committing a piece of code, that makes "cryptest" binary named as "cryptest.exe" on non-Windows platforms to make it uniform with documentation.

Also, it adds a new target "cryptest.exe", so the library could be built using the [command from the documentation](https://www.cryptopp.com/wiki/Linux#Make_and_Install): `make static dynamic cryptest.exe`

This patch is tested on Ubuntu 12.04 and 16.04.