### PR TITLE
Fixed install path for Windows in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,14 @@ set(export_name "cryptopp-targets")
 
 # Runtime package
 if (BUILD_SHARED)
-	install(TARGETS cryptopp-shared EXPORT ${export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+	install(
+			TARGETS cryptopp-shared
+			EXPORT ${export_name}
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	)
 endif()
 
 # Development package


### PR DESCRIPTION
MinGW produces two files for a shared target: import library and shared target. Import library must be located in /lib (or its Windows analogue), and shared library must be located in /bin.