### PR TITLE
Fix for CAST256 - Key-size

### DIFF
--- a/cast.h
+++ b/cast.h
@@ -58,7 +58,7 @@ public:
 
 //! \class CAST256_Info
 //! \brief CAST256 block cipher information
-struct CAST256_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32>
+struct CAST256_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 4>
 {
 	static const char *StaticAlgorithmName() {return "CAST-256";}
 };


### PR DESCRIPTION
Returned valid size is 16+1+1+1+1+1.... instead of 16+4... (16, 20, 24, 28, 32).
This fixes it.