### PR TITLE
Fix clang warnings about undefined variable templates in pkcspad.h

### DIFF
--- a/pkcspad.h
+++ b/pkcspad.h
@@ -54,6 +54,16 @@ CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA224>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA256>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA384>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA512>;
+#else
+extern template class PKCS_DigestDecoration<SHA1>;
+extern template class PKCS_DigestDecoration<RIPEMD160>;
+extern template class PKCS_DigestDecoration<Tiger>;
+extern template class PKCS_DigestDecoration<SHA224>;
+extern template class PKCS_DigestDecoration<SHA256>;
+extern template class PKCS_DigestDecoration<SHA384>;
+extern template class PKCS_DigestDecoration<SHA512>;
+extern template class PKCS_DigestDecoration<Weak1::MD2>;
+extern template class PKCS_DigestDecoration<Weak1::MD5>;
 #endif
 
 //! <a href="http://www.weidai.com/scan-mirror/sig.html#sem_PKCS1-1.5">EMSA-PKCS1-v1_5</a>


### PR DESCRIPTION
Recent versions of clang warn about missing `PKCS_DigestDecoration` definitions, specifically the decoration members.  For example:

    In file included from testpkcs.cpp:8:
    ./pkcspad.h:89:53: warning: instantiation of variable 'CryptoPP::PKCS_DigestDecoration<CryptoPP::SHA1>::decoration' required here, but no definition is available [-Wundefined-var-template]
                                    return HashIdentifier(PKCS_DigestDecoration<H>::decoration, (size_t)PKCS_DigestDecoration<H>::length);
                                                                                    ^
    ./pubkey.h:608:19: note: in instantiation of member function 'CryptoPP::PKCS1v15_SignatureMessageEncodingMethod::HashIdentifierLookup::HashIdentifierLookup2<CryptoPP::SHA1>::Lookup' requested here
            return L::Lookup();
                      ^
    ./pubkey.h:638:26: note: in instantiation of member function 'CryptoPP::TF_ObjectImplBase<CryptoPP::TF_VerifierBase, CryptoPP::TF_SignatureSchemeOptions<CryptoPP::TF_SS<CryptoPP::PKCS1v15, CryptoPP::SHA1, CryptoPP::RSA, int>,
          CryptoPP::RSA, CryptoPP::PKCS1v15_SignatureMessageEncodingMethod, CryptoPP::SHA1>, CryptoPP::RSAFunction>::GetHashIdentifier' requested here
    class CRYPTOPP_NO_VTABLE TF_ObjectImpl : public TF_ObjectImplBase<BASE, SCHEME_OPTIONS, KEY_CLASS>
                             ^
    ./pkcspad.h:32:20: note: forward declaration of template entity is here
            static const byte decoration[];
                              ^

This is because pkcspad.h doen't contain explicit instantiation declarations for `PKCS_DigestDecoration`.  These warnings can be fixed by adding them in the `!CRYPTOPP_IS_DLL` case, which appears to apply only to Windows.