### PR TITLE
fixed Keccak and SHA3 to support HMAC

### DIFF
--- a/keccak.h
+++ b/keccak.h
@@ -56,6 +56,8 @@ public:
 	void Restart();
 	void TruncatedFinal(byte *hash, size_t size);
 
+	unsigned int BlockSize() const { return r(); }
+
 protected:
 	inline unsigned int r() const {return 200 - 2 * m_digestSize;}
 
@@ -70,10 +72,14 @@ class Keccak_224 : public Keccak
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 28)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a Keccak-224 message digest
 	Keccak_224() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-224";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class Keccak_256
@@ -83,10 +89,14 @@ class Keccak_256 : public Keccak
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 32)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a Keccak-256 message digest
 	Keccak_256() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-256";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class Keccak_384
@@ -96,10 +106,14 @@ class Keccak_384 : public Keccak
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 48)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a Keccak-384 message digest
 	Keccak_384() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-384";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class Keccak_512
@@ -109,10 +123,14 @@ class Keccak_512 : public Keccak
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 64)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a Keccak-512 message digest
 	Keccak_512() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-512";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 NAMESPACE_END

--- a/keccak.h
+++ b/keccak.h
@@ -56,7 +56,7 @@ public:
 	void Restart();
 	void TruncatedFinal(byte *hash, size_t size);
 
-	unsigned int BlockSize() const { return r(); }
+	//unsigned int BlockSize() const { return r(); } // that's the idea behind it
 
 protected:
 	inline unsigned int r() const {return 200 - 2 * m_digestSize;}
@@ -77,6 +77,7 @@ public:
 	//! \brief Construct a Keccak-224 message digest
 	Keccak_224() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-224";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -94,6 +95,7 @@ public:
 	//! \brief Construct a Keccak-256 message digest
 	Keccak_256() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-256";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -111,6 +113,7 @@ public:
 	//! \brief Construct a Keccak-384 message digest
 	Keccak_384() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-384";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -128,6 +131,7 @@ public:
 	//! \brief Construct a Keccak-512 message digest
 	Keccak_512() : Keccak(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "Keccak-512";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC

--- a/sha3.h
+++ b/sha3.h
@@ -42,6 +42,7 @@ public:
 	void Restart();
 	void TruncatedFinal(byte *hash, size_t size);
 
+	unsigned int BlockSize() const { return r(); }
 protected:
 	inline unsigned int r() const {return 200 - 2 * m_digestSize;}
 
@@ -56,10 +57,14 @@ class SHA3_224 : public SHA3
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 28)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a SHA3-224 message digest
 	SHA3_224() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-224";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class SHA3_256
@@ -69,10 +74,14 @@ class SHA3_256 : public SHA3
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 32)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a SHA3-256 message digest
 	SHA3_256() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-256";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class SHA3_384
@@ -82,10 +91,14 @@ class SHA3_384 : public SHA3
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 48)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a SHA3-384 message digest
 	SHA3_384() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-384";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 //! \class SHA3_512
@@ -95,10 +108,14 @@ class SHA3_512 : public SHA3
 {
 public:
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 64)
+	CRYPTOPP_CONSTANT(BLOCKSIZE = 200 - 2 * DIGESTSIZE)
 
 	//! \brief Construct a SHA3-512 message digest
 	SHA3_512() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-512";}
+private:
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
+	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
 };
 
 NAMESPACE_END

--- a/sha3.h
+++ b/sha3.h
@@ -42,7 +42,7 @@ public:
 	void Restart();
 	void TruncatedFinal(byte *hash, size_t size);
 
-	unsigned int BlockSize() const { return r(); }
+	// unsigned int BlockSize() const { return r(); } // that's the idea behind it
 protected:
 	inline unsigned int r() const {return 200 - 2 * m_digestSize;}
 
@@ -62,6 +62,7 @@ public:
 	//! \brief Construct a SHA3-224 message digest
 	SHA3_224() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-224";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -79,6 +80,7 @@ public:
 	//! \brief Construct a SHA3-256 message digest
 	SHA3_256() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-256";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -96,6 +98,7 @@ public:
 	//! \brief Construct a SHA3-384 message digest
 	SHA3_384() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-384";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC
@@ -113,6 +116,7 @@ public:
 	//! \brief Construct a SHA3-512 message digest
 	SHA3_512() : SHA3(DIGESTSIZE) {}
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "SHA3-512";}
+	unsigned int BlockSize() const { return BLOCKSIZE; }
 private:
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE < 200); // ensure there was no underflow in the math
 	CRYPTOPP_COMPILE_ASSERT(BLOCKSIZE > DIGESTSIZE); // this is a general expectation by HMAC


### PR DESCRIPTION
added the blocksize constant and member functions to Keccak and SHA3
(and all derivatives) as well as some compile-time-checks