### PR TITLE
Restore MARS capability to use 448-bit keys

### DIFF
--- a/mars.h
+++ b/mars.h
@@ -13,7 +13,7 @@ NAMESPACE_BEGIN(CryptoPP)
 
 //! \class MARS_Info
 //! \brief MARS block cipher information
-struct MARS_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 8>
+struct MARS_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 58, 8>
 {
 	CRYPTOPP_CONSTEXPR static const char *StaticAlgorithmName() {return "MARS";}
 };

--- a/validat1.cpp
+++ b/validat1.cpp
@@ -2500,8 +2500,8 @@ bool ValidateMARS()
 	pass1 = enc.StaticGetValidKeyLength(16) == 16 && pass1;
 	pass1 = enc.StaticGetValidKeyLength(24) == 24 && pass1;
 	pass1 = enc.StaticGetValidKeyLength(32) == 32 && pass1;
-	pass1 = enc.StaticGetValidKeyLength(64) == 32 && pass1;
-	pass1 = enc.StaticGetValidKeyLength(128) == 32 && pass1;
+	pass1 = enc.StaticGetValidKeyLength(64) == 58 && pass1;
+	pass1 = enc.StaticGetValidKeyLength(128) == 58 && pass1;
 	pass1 = enc.StaticGetValidKeyLength(0) == enc.MinKeyLength() && pass1;
 	pass1 = enc.StaticGetValidKeyLength(SIZE_MAX) == enc.MaxKeyLength() && pass1;
 
@@ -2510,8 +2510,8 @@ bool ValidateMARS()
 	pass2 = dec.StaticGetValidKeyLength(16) == 16 && pass2;
 	pass2 = dec.StaticGetValidKeyLength(24) == 24 && pass2;
 	pass2 = dec.StaticGetValidKeyLength(32) == 32 && pass2;
-	pass2 = dec.StaticGetValidKeyLength(64) == 32 && pass2;
-	pass2 = dec.StaticGetValidKeyLength(128) == 32 && pass2;
+	pass2 = dec.StaticGetValidKeyLength(64) == 58 && pass2;
+	pass2 = dec.StaticGetValidKeyLength(128) == 58 && pass2;
 	pass2 = dec.StaticGetValidKeyLength(0) == dec.MinKeyLength() && pass2;
 	pass2 = dec.StaticGetValidKeyLength(SIZE_MAX) == dec.MaxKeyLength() && pass2;
 	cout << (pass1 && pass2 ? "passed:" : "FAILED:") << "  Algorithm key lengths\n";


### PR DESCRIPTION
There is no reason for MARS to be limited to 256-bit keys, and some applications (e.g., https://github.com/cryfs/cryfs.git) request larger keys.

This PR restores MARS 448-bit key capability.