### PR TITLE
Revert "Fix clang warnings about undefined variable templates in pkcspad.h"

### DIFF
--- a/pkcspad.h
+++ b/pkcspad.h
@@ -54,16 +54,6 @@ CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA224>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA256>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA384>;
 CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA512>;
-#else
-extern template class PKCS_DigestDecoration<SHA1>;
-extern template class PKCS_DigestDecoration<RIPEMD160>;
-extern template class PKCS_DigestDecoration<Tiger>;
-extern template class PKCS_DigestDecoration<SHA224>;
-extern template class PKCS_DigestDecoration<SHA256>;
-extern template class PKCS_DigestDecoration<SHA384>;
-extern template class PKCS_DigestDecoration<SHA512>;
-extern template class PKCS_DigestDecoration<Weak1::MD2>;
-extern template class PKCS_DigestDecoration<Weak1::MD5>;
 #endif
 
 //! <a href="http://www.weidai.com/scan-mirror/sig.html#sem_PKCS1-1.5">EMSA-PKCS1-v1_5</a>


### PR DESCRIPTION
Reverts cd06bac6bfe7270a1f.

```
g++ -DNDEBUG -g2 -O2 -fPIC -march=native -pipe -c queue.cpp
g++ -DNDEBUG -g2 -O2 -fPIC -march=native -pipe -c idea.cpp
pkcspad.cpp:15:58: error: explicit specialization of 'decoration' after
      instantiation
template<> const byte PKCS_DigestDecoration<Weak1::MD2>::decoration[] = ...
                                                         ^
./pkcspad.h:65:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Weak1::MD2>;
                      ^
pkcspad.cpp:16:66: error: explicit specialization of 'length' after
      instantiation
template<> const unsigned int PKCS_DigestDecoration<Weak1::MD2>::length ...
                                                                 ^
./pkcspad.h:65:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Weak1::MD2>;
                      ^
pkcspad.cpp:16:81: error: invalid application of 'sizeof' to an incomplete type
      'const byte []'
  ...= sizeof(PKCS_DigestDecoration<Weak1::MD2>::decoration);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pkcspad.cpp:18:58: error: explicit specialization of 'decoration' after
      instantiation
template<> const byte PKCS_DigestDecoration<Weak1::MD5>::decoration[] = ...
                                                         ^
./pkcspad.h:66:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Weak1::MD5>;
                      ^
pkcspad.cpp:19:66: error: explicit specialization of 'length' after
      instantiation
template<> const unsigned int PKCS_DigestDecoration<Weak1::MD5>::length ...
                                                                 ^
./pkcspad.h:66:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Weak1::MD5>;
                      ^
pkcspad.cpp:19:81: error: invalid application of 'sizeof' to an incomplete type
      'const byte []'
  ...= sizeof(PKCS_DigestDecoration<Weak1::MD5>::decoration);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pkcspad.cpp:21:57: error: explicit specialization of 'decoration' after
      instantiation
template<> const byte PKCS_DigestDecoration<RIPEMD160>::decoration[] = {...
                                                        ^
./pkcspad.h:59:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<RIPEMD160>;
                      ^
pkcspad.cpp:22:65: error: explicit specialization of 'length' after
      instantiation
template<> const unsigned int PKCS_DigestDecoration<RIPEMD160>::length ...
                                                                ^
./pkcspad.h:59:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<RIPEMD160>;
                      ^
pkcspad.cpp:22:80: error: invalid application of 'sizeof' to an incomplete type
      'const byte []'
  ...= sizeof(PKCS_DigestDecoration<RIPEMD160>::decoration);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pkcspad.cpp:24:53: error: explicit specialization of 'decoration' after
      instantiation
template<> const byte PKCS_DigestDecoration<Tiger>::decoration[] = {0x30...
                                                    ^
./pkcspad.h:60:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Tiger>;
                      ^
pkcspad.cpp:25:61: error: explicit specialization of 'length' after
      instantiation
template<> const unsigned int PKCS_DigestDecoration<Tiger>::length = siz...
                                                            ^
./pkcspad.h:60:23: note: explicit instantiation first required here
extern template class PKCS_DigestDecoration<Tiger>;
                      ^
pkcspad.cpp:25:76: error: invalid application of 'sizeof' to an incomplete type
      'const byte []'
  ...= sizeof(PKCS_DigestDecoration<Tiger>::decoration);
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
12 errors generated.
```
