### PR TITLE
Fixes #276

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(cryptopp_VERSION_PATCH 5)
 
 include(GNUInstallDirs)
 include(TestBigEndian)
+include(CheckCXXCompilerFlag)
 
 #============================================================================
 # Settable options
@@ -112,9 +113,10 @@ if ((NOT CRYPTOPP_CROSS_COMPILE) AND (NOT (WINDOWS OR WINDOWS_STORE OR WINDOWS_P
 	endif()
 endif()
 
-# -march=native for GCC, Clang and ICC on i386 and x86_64.
-if ((NOT CRYPTOPP_CROSS_COMPILE) AND ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel"))
-	if (("${UNAME_MACHINE}" MATCHES "i.86") OR ("${UNAME_MACHINE}" STREQUAL "x86_64") OR ("${UNAME_MACHINE}" STREQUAL "i86pc"))
+# -march=native for GCC, Clang and ICC in any version that does support it.
+if ((NOT CRYPTOPP_CROSS_COMPILE) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel"))
+	CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
+	if (COMPILER_OPT_ARCH_NATIVE_SUPPORTED AND NOT CMAKE_CXX_FLAGS MATCHES "-march=")
 		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 	endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,17 @@ cmake_minimum_required(VERSION 2.8.5 FATAL_ERROR)
 
 project(cryptopp)
 
+# Make RelWithDebInfo the default (it does e.g. add '-O2 -g -DNDEBUG' for GNU)
+#   If not in multi-configuration environments, no explicit build type or CXX 
+#   flags are set by the user and if we are the root CMakeLists.txt file.
+if (NOT CMAKE_CONFIGURATION_TYPES AND 
+    NOT CMAKE_NO_BUILD_TYPE AND
+    NOT CMAKE_BUILD_TYPE AND
+    NOT CMAKE_CXX_FLAGS AND
+    CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+	set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
+
 set(cryptopp_VERSION_MAJOR 5)
 set(cryptopp_VERSION_MINOR 6)
 set(cryptopp_VERSION_PATCH 5)
@@ -409,6 +420,7 @@ if (NOT CMAKE_VERSION VERSION_LESS 3.0.2)
 	include(FeatureSummary)
 	message(STATUS "Compiler: ${CXX}")
 	message(STATUS "Flags: ${CMAKE_CXX_FLAGS}")
+	message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 	feature_summary(WHAT ALL
 		VAR cryptoppFeatures)
         message(STATUS "${cryptoppFeatures}")


### PR DESCRIPTION
If no `CMAKE_BUILD_TYPE` is set, this does set the default to `RelWithDebInfo`. So it covers the intended functionality (e.g. setting `-g` which I think defaults to `-g2`) while being compatible with other build types/flags and platforms.

I also incorporated the changes suggested by Geoff in https://gist.github.com/geoffbeier/e9dcb0f623153ecdf042f14728eb878a, e.g. to check if the `CMAKE_CXX_FLAGS` are set or to print a message with the selected `CMAKE_BUILD_TYPE`. 

And I apologize for this being 4 commits in total (even I changed only one file and the author information of my last commit). I hope this not being a problem, I'm still not used to GitHub.