### PR TITLE
build: add DISABLE_CXXFLAGS_OPTIMIZATIONS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentati
 option(DISABLE_ASM "Disable ASM" OFF)
 option(DISABLE_SSSE3 "Disable SSSE3" OFF)
 option(DISABLE_AESNI "Disable AES-NI" OFF)
+option(DISABLE_CXXFLAGS_OPTIMIZATIONS "Disable CXXFLAGS optimizations" OFF)
 set(CRYPTOPP_DATA_DIR "" CACHE PATH "Crypto++ test data directory")
 
 #============================================================================
@@ -125,7 +126,7 @@ if ((NOT CRYPTOPP_CROSS_COMPILE) AND (NOT (WINDOWS OR WINDOWS_STORE OR WINDOWS_P
 endif()
 
 # -march=native for GCC, Clang and ICC in any version that does support it.
-if ((NOT CRYPTOPP_CROSS_COMPILE) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel"))
+if ((NOT DISABLE_CXXFLAGS_OPTIMIZATIONS) AND (NOT CRYPTOPP_CROSS_COMPILE) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel"))
 	CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
 	if (COMPILER_OPT_ARCH_NATIVE_SUPPORTED AND NOT CMAKE_CXX_FLAGS MATCHES "-march=")
 		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
@@ -134,25 +135,27 @@ endif()
 
 # Solaris specific 
 if ((NOT CRYPTOPP_CROSS_COMPILE) AND "${UNAME_SYSTEM}" STREQUAL "SunOS")
-	# SunCC needs -native
-	if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "SunPro")
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -native")
-	endif()
+	if (NOT DISABLE_CXXFLAGS_OPTIMIZATIONS)
+		# SunCC needs -native
+		if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "SunPro")
+			SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -native")
+		endif()
 
-	# Determine 32-bit vs 64-bit
-	set (ISA_CMD "isainfo")
-	set (ISA_ARG "-b")
-	execute_process(COMMAND ${ISA_CMD} ${ISA_ARG}
-		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-		RESULT_VARIABLE ISA_RESULT
-		OUTPUT_VARIABLE ISA_INFO)
-	string(REGEX REPLACE "\n$" "" ISA_INFO "${ISA_INFO}")
+		# Determine 32-bit vs 64-bit
+		set (ISA_CMD "isainfo")
+		set (ISA_ARG "-b")
+		execute_process(COMMAND ${ISA_CMD} ${ISA_ARG}
+			WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+			RESULT_VARIABLE ISA_RESULT
+			OUTPUT_VARIABLE ISA_INFO)
+		string(REGEX REPLACE "\n$" "" ISA_INFO "${ISA_INFO}")
 
-	# Set 64-bit or 32-bit
-	if ("${ISA_INFO}" STREQUAL "64")
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
-	else()
-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+		# Set 64-bit or 32-bit
+		if ("${ISA_INFO}" STREQUAL "64")
+			SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64")
+		else()
+			SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
+		endif()
 	endif()
 
 	# GCC needs to enable use of '/'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -49,6 +49,8 @@ IS_X86 := $(shell isainfo -k 2>/dev/null | grep -i -c "i386")
 IS_X64 := $(shell isainfo -k 2>/dev/null | grep -i -c "amd64")
 endif
 
+DISABLE_CXXFLAGS_OPTIMIZATIONS := 0
+
 ###########################################################
 #####                General Variables                #####
 ###########################################################
@@ -125,21 +127,23 @@ ifeq ($(IS_X86)$(IS_X32)$(IS_CYGWIN)$(IS_MINGW)$(SUN_COMPILER),00000)
  endif
 endif
 
-# Guard use of -march=native
-ifeq ($(GCC42_OR_LATER)$(IS_NETBSD),10)
-   CXXFLAGS += -march=native
-else ifneq ($(CLANG_COMPILER)$(INTEL_COMPILER),00)
-   CXXFLAGS += -march=native
-else
-  # GCC 3.3 and "unknown option -march="
-  # Ubuntu GCC 4.1 compiler crash with -march=native
-  # NetBSD GCC 4.8 compiler and "bad value (native) for -march= switch"
-  # Sun compiler is handled below
-  ifeq ($(SUN_COMPILER)$(IS_X64),01)
-    CXXFLAGS += -m64
-  else ifeq ($(SUN_COMPILER)$(IS_X86),01)
-    CXXFLAGS += -m32
-  endif # X86/X32/X64
+ifeq ($(DISABLE_CXXFLAGS_OPTIMIZATIONS),0)
+   # Guard use of -march=native
+   ifeq ($(GCC42_OR_LATER)$(IS_NETBSD),10)
+      CXXFLAGS += -march=native
+   else ifneq ($(CLANG_COMPILER)$(INTEL_COMPILER),00)
+      CXXFLAGS += -march=native
+   else
+     # GCC 3.3 and "unknown option -march="
+     # Ubuntu GCC 4.1 compiler crash with -march=native
+     # NetBSD GCC 4.8 compiler and "bad value (native) for -march= switch"
+     # Sun compiler is handled below
+     ifeq ($(SUN_COMPILER)$(IS_X64),01)
+       CXXFLAGS += -m64
+     else ifeq ($(SUN_COMPILER)$(IS_X86),01)
+       CXXFLAGS += -m32
+     endif # X86/X32/X64
+   endif
 endif
 
 # Aligned access required for -O3 and above due to vectorization


### PR DESCRIPTION
handy when packaging should control optimization without build system
masking. Especially handy when building to common architecture.

no change of behavior if DISABLE_CXXFLAGS_OPTIMIZATIONS is unset.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>