### PR TITLE
Add VectorSink

### DIFF
--- a/cryptlib.h
+++ b/cryptlib.h
@@ -50,7 +50,7 @@
 <dt>Input Source Classes<dd>
 	StringSource, ArraySource, FileSource, RandomNumberSource
 <dt>Output Sink Classes<dd>
-	StringSinkTemplate, StringSink, ArraySink, FileSink, RandomNumberSink
+	StringSinkTemplate, StringSink, VectorSink, ArraySink, FileSink, RandomNumberSink
 <dt>Filter Wrappers<dd>
 	StreamTransformationFilter, AuthenticatedEncryptionFilter, AuthenticatedDecryptionFilter, HashFilter,
 	HashVerificationFilter, SignerFilter, SignatureVerificationFilter

--- a/filters.h
+++ b/filters.h
@@ -1063,12 +1063,13 @@ template <class T>
 class StringSinkTemplate : public Bufferless<Sink>
 {
 public:
+	typedef typename T::value_type value_type;
 	virtual ~StringSinkTemplate() {}
 
 	/// \brief Construct a StringSinkTemplate
 	/// \param output std::basic_string<char> type
 	StringSinkTemplate(T &output)
-		: m_output(&output) {CRYPTOPP_ASSERT(sizeof(output[0])==1);}
+		: m_output(&output) {CRYPTOPP_ASSERT(sizeof(value_type)==1);}
 
 	void IsolatedInitialize(const NameValuePairs &parameters)
 		{if (!parameters.GetValue("OutputStringPointer", m_output)) throw InvalidArgument("StringSink: OutputStringPointer not specified");}
@@ -1076,14 +1077,12 @@ public:
 	size_t Put2(const byte *inString, size_t length, int messageEnd, bool blocking)
 	{
 		CRYPTOPP_UNUSED(messageEnd); CRYPTOPP_UNUSED(blocking);
-		typedef typename T::traits_type::char_type char_type;
-
 		if (length > 0)
 		{
 			typename T::size_type size = m_output->size();
 			if (length < size && size + length > m_output->capacity())
 				m_output->reserve(2*size);
-			m_output->append((const char_type *)inString, (const char_type *)inString+length);
+			m_output->insert(m_output->end(), (const value_type *)inString, (const value_type *)inString+length);
 		}
 		return 0;
 	}
@@ -1098,6 +1097,11 @@ private:
 /// \since Crypto++ 4.0
 DOCUMENTED_TYPEDEF(StringSinkTemplate<std::string>, StringSink)
 CRYPTOPP_DLL_TEMPLATE_CLASS StringSinkTemplate<std::string>;
+
+/// \brief Append input to a std::vector<byte> object
+/// \details VectorSink is a typedef for StringSinkTemplate<std::vector<byte> >.
+DOCUMENTED_TYPEDEF(StringSinkTemplate<std::vector<byte> >, VectorSink);
+CRYPTOPP_DLL_TEMPLATE_CLASS StringSinkTemplate<std::vector<byte> >;
 
 /// \brief Incorporates input into RNG as additional entropy
 /// \since Crypto++ 4.0

--- a/validat3.cpp
+++ b/validat3.cpp
@@ -41,6 +41,7 @@ bool ValidateAll(bool thorough)
 {
 	bool pass=TestSettings();
 	pass=TestOS_RNG() && pass;
+	pass=TestStringSink() && pass;
 	pass=TestRandomPool() && pass;
 #if !defined(NO_OS_DEPENDENCE) && defined(OS_RNG_AVAILABLE)
 	pass=TestAutoSeededX917() && pass;
@@ -559,6 +560,26 @@ bool TestOS_RNG()
 		std::cout << "\nNo operating system provided nonblocking random number generator, skipping test." << std::endl;
 
 	return pass;
+}
+
+bool TestStringSink()
+{
+	try
+	{
+		std::string in = "The quick brown fox jumps over the lazy dog";
+
+		std::string str;
+		StringSource s1(in, true, new StringSink(str));
+
+		std::vector<byte> vec;
+		StringSource s2(in, true, new VectorSink(vec));
+
+		return str.size() == vec.size() && std::equal(str.begin(), str.end(), vec.begin());
+	}
+	catch(...)
+	{
+	}
+	return false;
 }
 
 bool TestRandomPool()

--- a/validate.h
+++ b/validate.h
@@ -23,6 +23,7 @@ NAMESPACE_BEGIN(Test)
 bool ValidateAll(bool thorough);
 bool TestSettings();
 bool TestOS_RNG();
+bool TestStringSink();
 // bool TestSecRandom();
 bool TestRandomPool();
 #if !defined(NO_OS_DEPENDENCE)


### PR DESCRIPTION
✅ `T::traits_type::char_type char_type` → `T::value_type` (all STL containers have this)
✅ `sizeof(output[0])` → `sizeof(value_type)` (works with any containers, not just random access)
✅ `append` → `insert` (more universal)
✅ simple unit test

🚀 VectorSink typedef