### PR TITLE
Fix: GCC warning "type qualifiers ignored on function return type".

### DIFF
--- a/3way.h
+++ b/3way.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief ThreeWay block cipher information
 struct ThreeWay_Info : public FixedBlockSize<12>, public FixedKeyLength<12>, public VariableRounds<11>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "3-Way";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "3-Way";}
 };
 
 //! \class ThreeWay

--- a/adler32.h
+++ b/adler32.h
@@ -20,7 +20,7 @@ public:
 	void Update(const byte *input, size_t length);
 	void TruncatedFinal(byte *hash, size_t size);
 	unsigned int DigestSize() const {return DIGESTSIZE;}
-    CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Adler32";}
+    CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Adler32";}
     std::string AlgorithmName() const {return StaticAlgorithmName();}
 
 private:

--- a/arc4.h
+++ b/arc4.h
@@ -24,7 +24,7 @@ class CRYPTOPP_NO_VTABLE ARC4_Base : public VariableKeyLength<16, 1, 256>, publi
 public:
 	~ARC4_Base();
 
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "ARC4";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "ARC4";}
 
 	void GenerateBlock(byte *output, size_t size);
 	void DiscardBytes(size_t n);
@@ -59,7 +59,7 @@ DOCUMENTED_TYPEDEF(SymmetricCipherFinal<ARC4_Base>, ARC4)
 class CRYPTOPP_NO_VTABLE MARC4_Base : public ARC4_Base
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "MARC4";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "MARC4";}
 
 	typedef SymmetricCipherFinal<MARC4_Base> Encryption;
 	typedef SymmetricCipherFinal<MARC4_Base> Decryption;

--- a/blake2.h
+++ b/blake2.h
@@ -41,7 +41,7 @@ struct BLAKE2_Info : public VariableKeyLength<(T_64bit ? 64 : 32),0,(T_64bit ? 6
 	CRYPTOPP_CONSTANT(SALTSIZE = (T_64bit ? 16 : 8))
 	CRYPTOPP_CONSTANT(PERSONALIZATIONSIZE = (T_64bit ? 16 : 8))
 
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return (T_64bit ? "BLAKE2b" : "BLAKE2s");}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return (T_64bit ? "BLAKE2b" : "BLAKE2s");}
 };
 
 //! \class BLAKE2_ParameterBlock
@@ -180,7 +180,7 @@ public:
 
 	//! \brief Retrieve the static algorithm name
 	//! \returns the algorithm name (BLAKE2s or BLAKE2b)
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return BLAKE2_Info<T_64bit>::StaticAlgorithmName();}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return BLAKE2_Info<T_64bit>::StaticAlgorithmName();}
 
 	//! \brief Retrieve the object's name
 	//! \returns the object's algorithm name following RFC 7693

--- a/blowfish.h
+++ b/blowfish.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Blowfish block cipher information
 struct Blowfish_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 4, 56>, public FixedRounds<16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Blowfish";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Blowfish";}
 };
 
 // <a href="http://www.weidai.com/scan-mirror/cs.html#Blowfish">Blowfish</a>

--- a/camellia.h
+++ b/camellia.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Camellia block cipher information
 struct Camellia_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 8>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Camellia";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Camellia";}
 };
 
 //! \class Camellia

--- a/cast.h
+++ b/cast.h
@@ -23,7 +23,7 @@ protected:
 //! \brief CAST128 block cipher information
 struct CAST128_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 5, 16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "CAST-128";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "CAST-128";}
 };
 
 //! \class CAST128
@@ -68,7 +68,7 @@ public:
 //! \brief CAST256 block cipher information
 struct CAST256_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 4>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "CAST-256";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "CAST-256";}
 };
 
 //! \class CAST256

--- a/chacha.h
+++ b/chacha.h
@@ -25,7 +25,7 @@ NAMESPACE_BEGIN(CryptoPP)
 template <unsigned int R>
 struct ChaCha_Info : public VariableKeyLength<32, 16, 32, 16, SimpleKeyingInterface::UNIQUE_IV, 8>, public FixedRounds<R>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {
 		return (R==8?"ChaCha8":(R==12?"ChaCha12":(R==20?"ChaCha20":"ChaCha")));
 	}
 };

--- a/config.h
+++ b/config.h
@@ -922,10 +922,10 @@ NAMESPACE_END
 
 // http://stackoverflow.com/a/13867690/608639
 #if defined(CRYPTOPP_CXX11_CONSTEXPR)
-#  define CRYPTOPP_STATIC_CONSTEXPR static constexpr const
+#  define CRYPTOPP_STATIC_CONSTEXPR static constexpr
 #  define CRYPTOPP_CONSTEXPR constexpr
 #else
-#  define CRYPTOPP_STATIC_CONSTEXPR static const
+#  define CRYPTOPP_STATIC_CONSTEXPR static
 #  define CRYPTOPP_CONSTEXPR
 #endif // CRYPTOPP_CXX11_CONSTEXPR
 

--- a/crc.h
+++ b/crc.h
@@ -31,7 +31,7 @@ public:
 	void Update(const byte *input, size_t length);
 	void TruncatedFinal(byte *hash, size_t size);
 	unsigned int DigestSize() const {return DIGESTSIZE;}
-    CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "CRC32";}
+    CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "CRC32";}
     std::string AlgorithmName() const {return StaticAlgorithmName();}
 
 	void UpdateByte(byte b) {m_crc = m_tab[CRC32_INDEX(m_crc) ^ b] ^ CRC32_SHIFTED(m_crc);}
@@ -56,7 +56,7 @@ public:
 	void Update(const byte *input, size_t length);
 	void TruncatedFinal(byte *hash, size_t size);
 	unsigned int DigestSize() const {return DIGESTSIZE;}
-    CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "CRC32C";}
+    CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "CRC32C";}
     std::string AlgorithmName() const {return StaticAlgorithmName();}
 
 	void UpdateByte(byte b) {m_crc = m_tab[CRC32_INDEX(m_crc) ^ b] ^ CRC32_SHIFTED(m_crc);}

--- a/des.h
+++ b/des.h
@@ -30,7 +30,7 @@ protected:
 struct DES_Info : public FixedBlockSize<8>, public FixedKeyLength<8>
 {
 	// disable DES in DLL version by not exporting this function
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "DES";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "DES";}
 };
 
 //! \class DES
@@ -125,7 +125,7 @@ public:
 //! \brief DESX block cipher information
 struct DES_XEX3_Info : public FixedBlockSize<8>, public FixedKeyLength<24>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "DES-XEX3";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "DES-XEX3";}
 };
 
 //! \class DES_XEX3

--- a/eccrypto.h
+++ b/eccrypto.h
@@ -309,7 +309,7 @@ template <class EC>
 class DL_Algorithm_ECDSA : public DL_Algorithm_GDSA<typename EC::Point>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "ECDSA";}
+  CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "ECDSA";}
 
 #ifndef CRYPTOPP_MAINTAIN_BACKWARDS_COMPATIBILITY_562
 	virtual ~DL_Algorithm_ECDSA() {}
@@ -323,7 +323,7 @@ template <class EC>
 class DL_Algorithm_ECNR : public DL_Algorithm_NR<typename EC::Point>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "ECNR";}
+  CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "ECNR";}
 
 #ifndef CRYPTOPP_MAINTAIN_BACKWARDS_COMPATIBILITY_562
 	virtual ~DL_Algorithm_ECNR() {}

--- a/elgamal.h
+++ b/elgamal.h
@@ -138,7 +138,7 @@ struct ElGamal
 {
 	typedef DL_CryptoSchemeOptions<ElGamal, ElGamalKeys, int, int, int> SchemeOptions;
 
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "ElgamalEnc/Crypto++Padding";}
+  CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "ElgamalEnc/Crypto++Padding";}
 
 	typedef SchemeOptions::GroupParameters GroupParameters;
 	//! implements PK_Encryptor interface

--- a/emsa2.h
+++ b/emsa2.h
@@ -61,7 +61,7 @@ CRYPTOPP_DLL_TEMPLATE_CLASS EMSA2HashId<SHA512>;
 class CRYPTOPP_DLL EMSA2Pad : public EMSA2HashIdLookup<PK_DeterministicSignatureMessageEncodingMethod>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "EMSA2";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "EMSA2";}
 
 	size_t MinRepresentativeBitLength(size_t hashIdentifierLength, size_t digestLength) const
 		{CRYPTOPP_UNUSED(hashIdentifierLength); return 8*digestLength + 31;}

--- a/esign.h
+++ b/esign.h
@@ -98,7 +98,7 @@ template <class T>
 class EMSA5Pad : public PK_DeterministicSignatureMessageEncodingMethod
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "EMSA5";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "EMSA5";}
 
 	void ComputeMessageRepresentative(RandomNumberGenerator &rng,
 		const byte *recoverableMessage, size_t recoverableMessageLength,

--- a/gfpcrypt.h
+++ b/gfpcrypt.h
@@ -196,7 +196,7 @@ template <class T>
 class DL_Algorithm_GDSA : public DL_ElgamalLikeSignatureAlgorithm<T>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "DSA-1363";}
+  CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "DSA-1363";}
 
 #ifndef CRYPTOPP_MAINTAIN_BACKWARDS_COMPATIBILITY_562
 	virtual ~DL_Algorithm_GDSA() {}
@@ -234,7 +234,7 @@ template <class T>
 class DL_Algorithm_NR : public DL_ElgamalLikeSignatureAlgorithm<T>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "NR";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "NR";}
 
 #ifndef CRYPTOPP_MAINTAIN_BACKWARDS_COMPATIBILITY_562
 	virtual ~DL_Algorithm_NR() {}

--- a/gost.h
+++ b/gost.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief GOST block cipher information
 struct GOST_Info : public FixedBlockSize<8>, public FixedKeyLength<32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "GOST";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "GOST";}
 };
 
 //! \class GOST

--- a/idea.h
+++ b/idea.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \since Crypto++ 1.0
 struct IDEA_Info : public FixedBlockSize<8>, public FixedKeyLength<16>, public FixedRounds<8>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "IDEA";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "IDEA";}
 };
 
 //! \class IDEA

--- a/keccak.h
+++ b/keccak.h
@@ -50,7 +50,7 @@ public:
 	Keccak(unsigned int digestSize) : m_digestSize(digestSize) {Restart();}
 	unsigned int DigestSize() const {return m_digestSize;}
 	std::string AlgorithmName() const {return "Keccak-" + IntToString(m_digestSize*8);}
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() { return "Keccak"; }
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() { return "Keccak"; }
 	unsigned int OptimalDataAlignment() const {return GetAlignmentOf<word64>();}
 
 	void Update(const byte *input, size_t length);

--- a/luc.h
+++ b/luc.h
@@ -232,7 +232,7 @@ protected:
 class DL_Algorithm_LUC_HMP : public DL_ElgamalLikeSignatureAlgorithm<Integer>
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "LUC-HMP";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "LUC-HMP";}
 
 	void Sign(const DL_GroupParameters<Integer> &params, const Integer &x, const Integer &k, const Integer &e, Integer &r, Integer &s) const;
 	bool Verify(const DL_GroupParameters<Integer> &params, const DL_PublicKey<Integer> &publicKey, const Integer &e, const Integer &r, const Integer &s) const;

--- a/mars.h
+++ b/mars.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief MARS block cipher information
 struct MARS_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 56, 8>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "MARS";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "MARS";}
 };
 
 //! \class MARS

--- a/md2.h
+++ b/md2.h
@@ -17,7 +17,7 @@ public:
 	void TruncatedFinal(byte *hash, size_t size);
 	unsigned int DigestSize() const {return DIGESTSIZE;}
 	unsigned int BlockSize() const {return BLOCKSIZE;}
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "MD2";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "MD2";}
 
 	CRYPTOPP_CONSTANT(DIGESTSIZE = 16)
 	CRYPTOPP_CONSTANT(BLOCKSIZE = 16)

--- a/md4.h
+++ b/md4.h
@@ -15,7 +15,7 @@ class MD4 : public IteratedHashWithStaticTransform<word32, LittleEndian, 64, 16,
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "MD4";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "MD4";}
 };
 
 }

--- a/md5.h
+++ b/md5.h
@@ -16,7 +16,7 @@ class MD5 : public IteratedHashWithStaticTransform<word32, LittleEndian, 64, 16,
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "MD5";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "MD5";}
 };
 
 }

--- a/modes.h
+++ b/modes.h
@@ -112,7 +112,7 @@ class CRYPTOPP_DLL CRYPTOPP_NO_VTABLE CFB_ModePolicy : public ModePolicyCommonTe
 {
 public:
 	IV_Requirement IVRequirement() const {return RANDOM_IV;}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "CFB";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "CFB";}
 
 protected:
 	unsigned int GetBytesPerIteration() const {return m_feedbackSize;}
@@ -143,7 +143,7 @@ class CRYPTOPP_DLL CRYPTOPP_NO_VTABLE OFB_ModePolicy : public ModePolicyCommonTe
 public:
 	bool CipherIsRandomAccess() const {return false;}
 	IV_Requirement IVRequirement() const {return UNIQUE_IV;}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "OFB";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "OFB";}
 
 private:
 	unsigned int GetBytesPerIteration() const {return BlockSize();}
@@ -159,7 +159,7 @@ class CRYPTOPP_DLL CRYPTOPP_NO_VTABLE CTR_ModePolicy : public ModePolicyCommonTe
 public:
 	bool CipherIsRandomAccess() const {return true;}
 	IV_Requirement IVRequirement() const {return RANDOM_IV;}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "CTR";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "CTR";}
 
 protected:
 	virtual void IncrementCounterBy256();
@@ -216,7 +216,7 @@ public:
 	IV_Requirement IVRequirement() const {return NOT_RESYNCHRONIZABLE;}
 	unsigned int OptimalBlockSize() const {return BlockSize() * m_cipher->OptimalNumberOfParallelBlocks();}
 	void ProcessData(byte *outString, const byte *inString, size_t length);
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "ECB";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "ECB";}
 };
 
 //! \class CBC_ModeBase
@@ -227,7 +227,7 @@ public:
 	IV_Requirement IVRequirement() const {return UNPREDICTABLE_RANDOM_IV;}
 	bool RequireAlignedInput() const {return false;}
 	unsigned int MinLastBlockSize() const {return 0;}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "CBC";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "CBC";}
 };
 
 //! \class CBC_Encryption
@@ -246,7 +246,7 @@ public:
 	void SetStolenIV(byte *iv) {m_stolenIV = iv;}
 	unsigned int MinLastBlockSize() const {return BlockSize()+1;}
 	void ProcessLastBlock(byte *outString, const byte *inString, size_t length);
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "CBC/CTS";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "CBC/CTS";}
 
 protected:
 	void UncheckedSetKey(const byte *key, unsigned int length, const NameValuePairs &params)

--- a/panama.h
+++ b/panama.h
@@ -44,7 +44,7 @@ public:
 	PanamaHash() {Panama<B>::Reset();}
 	unsigned int DigestSize() const {return DIGESTSIZE;}
 	void TruncatedFinal(byte *hash, size_t size);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return B::ToEnum() == BIG_ENDIAN_ORDER ? "Panama-BE" : "Panama-LE";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return B::ToEnum() == BIG_ENDIAN_ORDER ? "Panama-BE" : "Panama-LE";}
 
 protected:
 	void Init() {Panama<B>::Reset();}
@@ -128,7 +128,7 @@ public:
 template <class B>
 struct PanamaCipherInfo : public FixedKeyLength<32, SimpleKeyingInterface::UNIQUE_IV, 32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return B::ToEnum() == BIG_ENDIAN_ORDER ? "Panama-BE" : "Panama-LE";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return B::ToEnum() == BIG_ENDIAN_ORDER ? "Panama-BE" : "Panama-LE";}
 };
 
 //! \class PanamaCipherPolicy

--- a/pkcspad.h
+++ b/pkcspad.h
@@ -22,7 +22,7 @@ NAMESPACE_BEGIN(CryptoPP)
 class PKCS_EncryptionPaddingScheme : public PK_EncryptionMessageEncodingMethod
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "EME-PKCS1-v1_5";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "EME-PKCS1-v1_5";}
 
 	size_t MaxUnpaddedLength(size_t paddedLength) const;
 	void Pad(RandomNumberGenerator &rng, const byte *raw, size_t inputLength, byte *padded, size_t paddedLength, const NameValuePairs &parameters) const;
@@ -67,7 +67,7 @@ CRYPTOPP_DLL_TEMPLATE_CLASS PKCS_DigestDecoration<SHA512>;
 class CRYPTOPP_DLL PKCS1v15_SignatureMessageEncodingMethod : public PK_DeterministicSignatureMessageEncodingMethod
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "EMSA-PKCS1-v1_5";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "EMSA-PKCS1-v1_5";}
 
 	size_t MinRepresentativeBitLength(size_t hashIdentifierSize, size_t digestSize) const
 		{return 8 * (digestSize + hashIdentifierSize + 10);}

--- a/pubkey.h
+++ b/pubkey.h
@@ -719,7 +719,7 @@ CRYPTOPP_DLL void CRYPTOPP_API P1363_MGF1KDF2_Common(HashTransformation &hash, b
 class P1363_MGF1 : public MaskGeneratingFunction
 {
 public:
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "MGF1";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "MGF1";}
 	void GenerateAndMask(HashTransformation &hash, byte *output, size_t outputLength, const byte *input, size_t inputLength, bool mask = true) const
 	{
 		P1363_MGF1KDF2_Common(hash, output, outputLength, input, inputLength, NULL, 0, mask, 0);
@@ -1986,7 +1986,7 @@ public:
 	virtual ~DL_KeyAgreementAlgorithm_DH() {}
 #endif
 
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName()
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName()
 		{return COFACTOR_OPTION::ToEnum() == INCOMPATIBLE_COFACTOR_MULTIPLICTION ? "DHC" : "DH";}
 
 	Element AgreeWithEphemeralPrivateKey(const DL_GroupParameters<Element> &params, const DL_FixedBasePrecomputation<Element> &publicPrecomputation, const Integer &privateExponent) const

--- a/rc2.h
+++ b/rc2.h
@@ -18,7 +18,7 @@ struct RC2_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 1, 128>
 {
 	CRYPTOPP_CONSTANT(DEFAULT_EFFECTIVE_KEYLENGTH = 1024)
 	CRYPTOPP_CONSTANT(MAX_EFFECTIVE_KEYLENGTH = 1024)
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RC2";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RC2";}
 };
 
 //! \class RC2

--- a/rc5.h
+++ b/rc5.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \since Crypto++ 1.0
 struct RC5_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 0, 255>, public VariableRounds<16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RC5";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RC5";}
 	typedef word32 RC5_WORD;
 };
 

--- a/rc6.h
+++ b/rc6.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief RC6 block cipher information
 struct RC6_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 8>, public VariableRounds<20>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RC6";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RC6";}
 	typedef word32 RC6_WORD;
 };
 

--- a/ripemd.h
+++ b/ripemd.h
@@ -19,7 +19,7 @@ class RIPEMD160 : public IteratedHashWithStaticTransform<word32, LittleEndian, 6
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RIPEMD-160";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RIPEMD-160";}
 };
 
 //! \class RIPEMD320
@@ -31,7 +31,7 @@ class RIPEMD320 : public IteratedHashWithStaticTransform<word32, LittleEndian, 6
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RIPEMD-320";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RIPEMD-320";}
 };
 
 //! \class RIPEMD128
@@ -44,7 +44,7 @@ class RIPEMD128 : public IteratedHashWithStaticTransform<word32, LittleEndian, 6
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RIPEMD-128";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RIPEMD-128";}
 };
 
 //! \class RIPEMD256
@@ -57,7 +57,7 @@ class RIPEMD256 : public IteratedHashWithStaticTransform<word32, LittleEndian, 6
 public:
 	static void InitState(HashWordType *state);
 	static void Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "RIPEMD-256";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "RIPEMD-256";}
 };
 
 NAMESPACE_END

--- a/rsa.h
+++ b/rsa.h
@@ -157,7 +157,7 @@ public:
 //! \since Crypto++ 1.0
 struct CRYPTOPP_DLL RSA
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "RSA";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "RSA";}
 	typedef RSAFunction PublicKey;
 	typedef InvertibleRSAFunction PrivateKey;
 };
@@ -189,7 +189,7 @@ struct RSASS : public TF_SS<STANDARD, H, RSA>
 //! \since Crypto++ 1.0
 struct CRYPTOPP_DLL RSA_ISO
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "RSA-ISO";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "RSA-ISO";}
 	typedef RSAFunction_ISO PublicKey;
 	typedef InvertibleRSAFunction_ISO PrivateKey;
 };

--- a/safer.h
+++ b/safer.h
@@ -66,7 +66,7 @@ protected:
 //! \brief SAFER-K block cipher information
 struct SAFER_K_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 8, 16, 8>, public VariableRounds<10, 1, 13>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "SAFER-K";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "SAFER-K";}
 };
 
 //! \class SAFER_K
@@ -83,7 +83,7 @@ public:
 //! \brief SAFER-SK block cipher information
 struct SAFER_SK_Info : public FixedBlockSize<8>, public VariableKeyLength<16, 8, 16, 8>, public VariableRounds<10, 1, 13>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "SAFER-SK";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "SAFER-SK";}
 };
 
 //! \class SAFER_SK

--- a/salsa.h
+++ b/salsa.h
@@ -22,7 +22,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Salsa20 stream cipher information
 struct Salsa20_Info : public VariableKeyLength<32, 16, 32, 16, SimpleKeyingInterface::UNIQUE_IV, 8>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Salsa20";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Salsa20";}
 };
 
 //! \class Salsa20_Policy
@@ -58,7 +58,7 @@ struct Salsa20 : public Salsa20_Info, public SymmetricCipherDocumentation
 //! \brief XSalsa20 stream cipher information
 struct XSalsa20_Info : public FixedKeyLength<32, SimpleKeyingInterface::UNIQUE_IV, 24>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "XSalsa20";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "XSalsa20";}
 };
 
 //! \class XSalsa20_Policy

--- a/seal.h
+++ b/seal.h
@@ -17,7 +17,7 @@ NAMESPACE_BEGIN(CryptoPP)
 template <class B = BigEndian>
 struct SEAL_Info : public FixedKeyLength<20, SimpleKeyingInterface::INTERNALLY_GENERATED_IV, 4>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return B::ToEnum() == LITTLE_ENDIAN_ORDER ? "SEAL-3.0-LE" : "SEAL-3.0-BE";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return B::ToEnum() == LITTLE_ENDIAN_ORDER ? "SEAL-3.0-LE" : "SEAL-3.0-BE";}
 };
 
 //! \class SEAL_Policy

--- a/seed.h
+++ b/seed.h
@@ -17,7 +17,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \since Crypto++ 5.6.0
 struct SEED_Info : public FixedBlockSize<16>, public FixedKeyLength<16>, public FixedRounds<16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "SEED";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "SEED";}
 };
 
 //! \class SEED

--- a/serpent.h
+++ b/serpent.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Serpent block cipher information
 struct Serpent_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 8>, public FixedRounds<32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Serpent";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Serpent";}
 };
 
 //! \class Serpent

--- a/sha.h
+++ b/sha.h
@@ -27,7 +27,7 @@ class CRYPTOPP_DLL SHA1 : public IteratedHashWithStaticTransform<word32, BigEndi
 public:
 	static void CRYPTOPP_API InitState(HashWordType *state);
 	static void CRYPTOPP_API Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "SHA-1";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "SHA-1";}
 };
 
 typedef SHA1 SHA;	// for backwards compatibility
@@ -44,7 +44,7 @@ public:
 #endif
 	static void CRYPTOPP_API InitState(HashWordType *state);
 	static void CRYPTOPP_API Transform(word32 *digest, const word32 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "SHA-256";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "SHA-256";}
 };
 
 //! \class SHA224
@@ -59,7 +59,7 @@ public:
 #endif
 	static void CRYPTOPP_API InitState(HashWordType *state);
 	static void CRYPTOPP_API Transform(word32 *digest, const word32 *data) {SHA256::Transform(digest, data);}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "SHA-224";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "SHA-224";}
 };
 
 //! \class SHA512
@@ -71,7 +71,7 @@ class CRYPTOPP_DLL SHA512 : public IteratedHashWithStaticTransform<word64, BigEn
 public:
 	static void CRYPTOPP_API InitState(HashWordType *state);
 	static void CRYPTOPP_API Transform(word64 *digest, const word64 *data);
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "SHA-512";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "SHA-512";}
 };
 
 //! \class SHA384
@@ -83,7 +83,7 @@ class CRYPTOPP_DLL SHA384 : public IteratedHashWithStaticTransform<word64, BigEn
 public:
 	static void CRYPTOPP_API InitState(HashWordType *state);
 	static void CRYPTOPP_API Transform(word64 *digest, const word64 *data) {SHA512::Transform(digest, data);}
-	CRYPTOPP_STATIC_CONSTEXPR char* const CRYPTOPP_API StaticAlgorithmName() {return "SHA-384";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* CRYPTOPP_API StaticAlgorithmName() {return "SHA-384";}
 };
 
 NAMESPACE_END

--- a/sha3.h
+++ b/sha3.h
@@ -36,7 +36,7 @@ public:
 	SHA3(unsigned int digestSize) : m_digestSize(digestSize) {Restart();}
 	unsigned int DigestSize() const {return m_digestSize;}
 	std::string AlgorithmName() const {return "SHA3-" + IntToString(m_digestSize*8);}
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() { return "SHA3"; }
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() { return "SHA3"; }
 	unsigned int OptimalDataAlignment() const {return GetAlignmentOf<word64>();}
 
 	void Update(const byte *input, size_t length);

--- a/shacal2.h
+++ b/shacal2.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief SHACAL2 block cipher information
 struct SHACAL2_Info : public FixedBlockSize<32>, public VariableKeyLength<16, 16, 64>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "SHACAL-2";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "SHACAL-2";}
 };
 
 //! \class SHACAL2

--- a/shark.h
+++ b/shark.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief SHARK block cipher information
 struct SHARK_Info : public FixedBlockSize<8>, public FixedKeyLength<16>, public VariableRounds<6, 2>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "SHARK-E";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "SHARK-E";}
 };
 
 //! \class SHARK

--- a/socketft.cpp
+++ b/socketft.cpp
@@ -512,7 +512,7 @@ unsigned int SocketReceiver::GetReceiveResult()
 // *************************************************************
 
 SocketSender::SocketSender(Socket &s)
-	: m_s(s), m_resultPending(false), m_lastResult(0)
+	: m_s(s), m_lastResult(0), m_resultPending(false)
 {
 	m_event.AttachHandle(CreateEvent(NULL, true, false, NULL), true);
 	m_s.CheckAndHandleError("CreateEvent", m_event.HandleValid());

--- a/sosemanuk.h
+++ b/sosemanuk.h
@@ -23,7 +23,7 @@ NAMESPACE_BEGIN(CryptoPP)
 	//! \since Crypto++ 5.5
 struct SosemanukInfo : public VariableKeyLength<16, 1, 32, 1, SimpleKeyingInterface::UNIQUE_IV, 16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Sosemanuk";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Sosemanuk";}
 };
 
 //! \class SosemanukPolicy

--- a/square.h
+++ b/square.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Square block cipher information
 struct Square_Info : public FixedBlockSize<16>, public FixedKeyLength<16>, FixedRounds<8>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Square";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Square";}
 };
 
 //! \class Square

--- a/tea.h
+++ b/tea.h
@@ -16,7 +16,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief TEA block cipher information
 struct TEA_Info : public FixedBlockSize<8>, public FixedKeyLength<16>, public VariableRounds<32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "TEA";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "TEA";}
 };
 
 //! \class TEA
@@ -64,7 +64,7 @@ typedef TEA::Decryption TEADecryption;
 //! \brief XTEA block cipher information
 struct XTEA_Info : public FixedBlockSize<8>, public FixedKeyLength<16>, public VariableRounds<32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "XTEA";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "XTEA";}
 };
 
 //! \class XTEA
@@ -109,7 +109,7 @@ public:
 //! \brief BTEA block cipher information
 struct BTEA_Info : public FixedKeyLength<16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "BTEA";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "BTEA";}
 };
 
 //! \class BTEA

--- a/tiger.h
+++ b/tiger.h
@@ -19,7 +19,7 @@ public:
 	static void InitState(HashWordType *state);
 	static void Transform(word64 *digest, const word64 *data);
 	void TruncatedFinal(byte *hash, size_t size);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Tiger";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Tiger";}
 
 protected:
 	static const word64 table[4*256+3];

--- a/twofish.h
+++ b/twofish.h
@@ -15,7 +15,7 @@ NAMESPACE_BEGIN(CryptoPP)
 //! \brief Twofish block cipher information
 struct Twofish_Info : public FixedBlockSize<16>, public VariableKeyLength<16, 16, 32, 8>, FixedRounds<16>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Twofish";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Twofish";}
 };
 
 //! \class Twofish

--- a/wait.cpp
+++ b/wait.cpp
@@ -164,6 +164,7 @@ WaitObjectContainer::~WaitObjectContainer()
 			CRYPTOPP_ASSERT(dwResult < (DWORD)m_threads.size());
 #else
 			DWORD dwResult = ::WaitForMultipleObjects((DWORD)m_threads.size(), threadHandles, TRUE, INFINITE);
+			CRYPTOPP_UNUSED(dwResult);
 			CRYPTOPP_ASSERT(dwResult < (DWORD)m_threads.size());
 #endif
 

--- a/wake.h
+++ b/wake.h
@@ -19,7 +19,7 @@ NAMESPACE_BEGIN(CryptoPP)
 template <class B = BigEndian>
 struct WAKE_OFB_Info : public FixedKeyLength<32>
 {
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return B::ToEnum() == LITTLE_ENDIAN_ORDER ? "WAKE-OFB-LE" : "WAKE-OFB-BE";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return B::ToEnum() == LITTLE_ENDIAN_ORDER ? "WAKE-OFB-LE" : "WAKE-OFB-BE";}
 };
 
 class CRYPTOPP_NO_VTABLE WAKE_Base

--- a/whrlpool.h
+++ b/whrlpool.h
@@ -13,7 +13,7 @@ public:
 	static void InitState(HashWordType *state);
 	static void Transform(word64 *digest, const word64 *data);
 	void TruncatedFinal(byte *hash, size_t size);
-	CRYPTOPP_STATIC_CONSTEXPR char* const StaticAlgorithmName() {return "Whirlpool";}
+	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Whirlpool";}
 };
 
 NAMESPACE_END


### PR DESCRIPTION
This pedantic message appeared all over the code. Also removed one warning about an unused variable in release build.