### PR TITLE
Fix -Wshadow compiler warnings

### DIFF
--- a/algebra.cpp
+++ b/algebra.cpp
@@ -205,9 +205,9 @@ template <class Element, class Iterator> Element GeneralCascadeMultiplication(co
 
 struct WindowSlider
 {
-	WindowSlider(const Integer &expIn, bool fastNegate, unsigned int windowSizeIn=0)
+	WindowSlider(const Integer &expIn, bool _fastNegate, unsigned int windowSizeIn=0)
 		: exp(expIn), windowModulus(Integer::One()), windowSize(windowSizeIn), windowBegin(0), expWindow(0)
-		, fastNegate(fastNegate), negateNext(false), firstTime(true), finished(false)
+		, fastNegate(_fastNegate), negateNext(false), firstTime(true), finished(false)
 	{
 		if (windowSize == 0)
 		{

--- a/algebra.h
+++ b/algebra.h
@@ -250,7 +250,7 @@ struct BaseAndExponent
 {
 public:
 	BaseAndExponent() {}
-	BaseAndExponent(const T &base, const E &exponent) : base(base), exponent(exponent) {}
+	BaseAndExponent(const T &_base, const E &_exponent) : base(_base), exponent(_exponent) {}
 	bool operator<(const BaseAndExponent<T, E> &rhs) const {return exponent < rhs.exponent;}
 	T base;
 	E exponent;

--- a/blumshub.cpp
+++ b/blumshub.cpp
@@ -45,9 +45,9 @@ void PublicBlumBlumShub::ProcessData(byte *outString, const byte *inString, size
 		*outString++ = *inString++ ^ PublicBlumBlumShub::GenerateByte();
 }
 
-BlumBlumShub::BlumBlumShub(const Integer &p, const Integer &q, const Integer &seed)
-	: PublicBlumBlumShub(p*q, seed),
-	  p(p), q(q),
+BlumBlumShub::BlumBlumShub(const Integer &_p, const Integer &_q, const Integer &seed)
+	: PublicBlumBlumShub(_p*_q, seed),
+	  p(_p), q(_q),
 	  x0(modn.Square(seed))
 {
 }

--- a/camellia.cpp
+++ b/camellia.cpp
@@ -50,11 +50,11 @@ NAMESPACE_BEGIN(CryptoPP)
 	word32 th = lh ^ kh;					\
 	word32 tl = ll ^ kl;					\
 	word32 d = SP[0][GETBYTE(tl,0)] ^ SP[1][GETBYTE(tl,3)] ^ SP[2][GETBYTE(tl,2)] ^ SP[3][GETBYTE(tl,1)];	\
-	word32 u = SP[0][GETBYTE(th,3)] ^ SP[1][GETBYTE(th,2)] ^ SP[2][GETBYTE(th,1)] ^ SP[3][GETBYTE(th,0)];	\
-	d ^= u;									\
+	word32 __u = SP[0][GETBYTE(th,3)] ^ SP[1][GETBYTE(th,2)] ^ SP[2][GETBYTE(th,1)] ^ SP[3][GETBYTE(th,0)];	\
+	d ^= __u;									\
 	rh ^= d;								\
 	rl ^= d;								\
-	rl ^= rotrFixed(u, 8);}
+	rl ^= rotrFixed(__u, 8);}
 
 #define DOUBLE_ROUND(lh, ll, rh, rl, k0, k1, k2, k3)	\
 	ROUND(lh, ll, rh, rl, k0, k1)						\

--- a/eccrypto.cpp
+++ b/eccrypto.cpp
@@ -85,10 +85,10 @@ template <class T> struct EcRecommendedParameters;
 
 template<> struct EcRecommendedParameters<EC2N>
 {
-	EcRecommendedParameters(const OID &oid, unsigned int t2, unsigned int t3, unsigned int t4, const char *a, const char *b, const char *g, const char *n, unsigned int h)
-		: oid(oid), t0(0), t1(0), t2(t2), t3(t3), t4(t4), a(a), b(b), g(g), n(n), h(h) {}
-	EcRecommendedParameters(const OID &oid, unsigned int t0, unsigned int t1, unsigned int t2, unsigned int t3, unsigned int t4, const char *a, const char *b, const char *g, const char *n, unsigned int h)
-		: oid(oid), t0(t0), t1(t1), t2(t2), t3(t3), t4(t4), a(a), b(b), g(g), n(n), h(h) {}
+	EcRecommendedParameters(const OID &_oid, unsigned int _t2, unsigned int _t3, unsigned int _t4, const char *_a, const char *_b, const char *_g, const char *_n, unsigned int _h)
+		: oid(_oid), t0(0), t1(0), t2(_t2), t3(_t3), t4(_t4), a(_a), b(_b), g(_g), n(_n), h(_h) {}
+	EcRecommendedParameters(const OID &_oid, unsigned int _t0, unsigned int _t1, unsigned int _t2, unsigned int _t3, unsigned int _t4, const char *_a, const char *_b, const char *_g, const char *_n, unsigned int _h)
+		: oid(_oid), t0(_t0), t1(_t1), t2(_t2), t3(_t3), t4(_t4), a(_a), b(_b), g(_g), n(_n), h(_h) {}
 	EC2N *NewEC() const
 	{
 		StringSource ssA(a, true, new HexDecoder);
@@ -107,8 +107,8 @@ template<> struct EcRecommendedParameters<EC2N>
 
 template<> struct EcRecommendedParameters<ECP>
 {
-	EcRecommendedParameters(const OID &oid, const char *p, const char *a, const char *b, const char *g, const char *n, unsigned int h)
-		: oid(oid), p(p), a(a), b(b), g(g), n(n), h(h) {}
+	EcRecommendedParameters(const OID &_oid, const char *_p, const char *_a, const char *_b, const char *_g, const char *_n, unsigned int _h)
+		: oid(_oid), p(_p), a(_a), b(_b), g(_g), n(_n), h(_h) {}
 	ECP *NewEC() const
 	{
 		StringSource ssP(p, true, new HexDecoder);

--- a/ecp.cpp
+++ b/ecp.cpp
@@ -289,8 +289,8 @@ template <class T, class Iterator> void ParallelInvert(const AbstractRing<T> &ri
 struct ProjectivePoint
 {
 	ProjectivePoint() {}
-	ProjectivePoint(const Integer &x, const Integer &y, const Integer &z)
-		: x(x), y(y), z(z)	{}
+	ProjectivePoint(const Integer &_x, const Integer &_y, const Integer &_z)
+		: x(_x), y(_y), z(_z)	{}
 
 	Integer x,y,z;
 };
@@ -343,7 +343,7 @@ public:
 struct ZIterator
 {
 	ZIterator() {}
-	ZIterator(std::vector<ProjectivePoint>::iterator it) : it(it) {}
+	ZIterator(std::vector<ProjectivePoint>::iterator _it) : it(_it) {}
 	Integer& operator*() {return it->z;}
 	int operator-(ZIterator it2) {return int(it-it2.it);}
 	ZIterator operator+(int i) {return ZIterator(it+i);}

--- a/ecpoint.h
+++ b/ecpoint.h
@@ -28,8 +28,8 @@ struct CRYPTOPP_DLL ECPPoint
 
 	//! \brief Construct an ECPPoint from coordinates
 	//! \details identity is set to <tt>false</tt>
-	ECPPoint(const Integer &x, const Integer &y)
-		: x(x), y(y), identity(false) {}
+	ECPPoint(const Integer &_x, const Integer &_y)
+		: x(_x), y(_y), identity(false) {}
 
 	//! \brief Tests points for equality
 	//! \param t the other point
@@ -62,8 +62,8 @@ struct CRYPTOPP_DLL EC2NPoint
 
 	//! \brief Construct an EC2NPoint from coordinates
 	//! \details identity is set to <tt>false</tt>
-	EC2NPoint(const PolynomialMod2 &x, const PolynomialMod2 &y)
-		: x(x), y(y), identity(false) {}
+	EC2NPoint(const PolynomialMod2 &_x, const PolynomialMod2 &_y)
+		: x(_x), y(_y), identity(false) {}
 
 	//! \brief Tests points for equality
 	//! \param t the other point

--- a/gf2n.h
+++ b/gf2n.h
@@ -351,8 +351,8 @@ class CRYPTOPP_DLL GF2NPP : public GF2NP
 {
 public:
 	// polynomial modulus = x^t0 + x^t1 + x^t2 + x^t3 + x^t4, t0 > t1 > t2 > t3 > t4
-	GF2NPP(unsigned int t0, unsigned int t1, unsigned int t2, unsigned int t3, unsigned int t4)
-		: GF2NP(PolynomialMod2::Pentanomial(t0, t1, t2, t3, t4)), t0(t0), t1(t1), t2(t2), t3(t3) {}
+	GF2NPP(unsigned int _t0, unsigned int _t1, unsigned int _t2, unsigned int _t3, unsigned int t4)
+		: GF2NP(PolynomialMod2::Pentanomial(_t0, _t1, _t2, _t3, t4)), t0(_t0), t1(_t1), t2(_t2), t3(_t3) {}
 
 	GF2NP * Clone() const {return new GF2NPP(*this);}
 	void DEREncode(BufferedTransformation &bt) const;

--- a/validat1.cpp
+++ b/validat1.cpp
@@ -1198,8 +1198,8 @@ bool BlockTransformationTest(const CipherFactory &cg, BufferedTransformation &va
 class FilterTester : public Unflushable<Sink>
 {
 public:
-	FilterTester(const byte *validOutput, size_t outputLen)
-		: validOutput(validOutput), outputLen(outputLen), counter(0), fail(false) {}
+	FilterTester(const byte *_validOutput, size_t _outputLen)
+		: validOutput(_validOutput), outputLen(_outputLen), counter(0), fail(false) {}
 	void PutByte(byte inByte)
 	{
 		if (counter >= outputLen || validOutput[counter] != inByte)

--- a/validat3.cpp
+++ b/validat3.cpp
@@ -52,11 +52,11 @@ USING_NAMESPACE(std)
 
 struct HashTestTuple
 {
-	HashTestTuple(const char *input, const char *output, unsigned int repeatTimes=1)
-		: input((byte *)input), output((byte *)output), inputLen(strlen(input)), repeatTimes(repeatTimes) {}
+	HashTestTuple(const char *_input, const char *_output, unsigned int _repeatTimes=1)
+		: input((byte *)_input), output((byte *)_output), inputLen(strlen(_input)), repeatTimes(_repeatTimes) {}
 
-	HashTestTuple(const char *input, unsigned int inputLen, const char *output, unsigned int repeatTimes)
-		: input((byte *)input), output((byte *)output), inputLen(inputLen), repeatTimes(repeatTimes) {}
+	HashTestTuple(const char *_input, unsigned int _inputLen, const char *_output, unsigned int _repeatTimes)
+		: input((byte *)_input), output((byte *)_output), inputLen(_inputLen), repeatTimes(_repeatTimes) {}
 
 	const byte *input, *output;
 	size_t inputLen;

--- a/xtr.h
+++ b/xtr.h
@@ -18,7 +18,7 @@ class GFP2Element
 {
 public:
 	GFP2Element() {}
-	GFP2Element(const Integer &c1, const Integer &c2) : c1(c1), c2(c2) {}
+	GFP2Element(const Integer &_c1, const Integer &_c2) : c1(_c1), c2(_c2) {}
 	GFP2Element(const byte *encodedElement, unsigned int size)
 		: c1(encodedElement, size/2), c2(encodedElement+size/2, size/2) {}
 

--- a/zinflate.h
+++ b/zinflate.h
@@ -56,7 +56,7 @@ private:
 
 	struct CodeInfo
 	{
-		CodeInfo(code_t code=0, unsigned int len=0, value_t value=0) : code(code), len(len), value(value) {}
+		CodeInfo(code_t _code=0, unsigned int _len=0, value_t _value=0) : code(_code), len(_len), value(_value) {}
 		inline bool operator<(const CodeInfo &rhs) const {return code < rhs.code;}
 		code_t code;
 		unsigned int len;


### PR DESCRIPTION
When compiling using the -Wshadow compiler flag, quite a few warnings pop up. Clean up all instances of shadowing.