### PR TITLE
Replace assert with void instruction

### DIFF
--- a/trap.h
+++ b/trap.h
@@ -89,7 +89,7 @@
 // Remove CRYPTOPP_ASSERT in non-debug builds.
 //  Can't use CRYPTOPP_UNUSED due to circular dependency
 #ifndef CRYPTOPP_ASSERT
-#  define CRYPTOPP_ASSERT(exp)
+#  define CRYPTOPP_ASSERT(exp) (void)0
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)


### PR DESCRIPTION
In release builds replace assert with void instruction `(void)0`. Otherwise in some places you will end up with statements like `if (...) ;` and some compiler will complain about it.