### PR TITLE
Suppress warning also for VS2017

### DIFF
--- a/wait.h
+++ b/wait.h
@@ -34,7 +34,7 @@
 
 // http://connect.microsoft.com/VisualStudio/feedback/details/1581706
 //   and http://github.com/weidai11/cryptopp/issues/214
-#if CRYPTOPP_MSC_VERSION == 1900
+#if (CRYPTOPP_MSC_VERSION >= 1900) && (CRYPTOPP_MSC_VERSION < 2000)
 # pragma warning(push)
 # pragma warning(disable: 4589)
 #endif
@@ -226,7 +226,7 @@ private:
 
 NAMESPACE_END
 
-#if CRYPTOPP_MSC_VERSION == 1900
+#if (CRYPTOPP_MSC_VERSION >= 1900) && (CRYPTOPP_MSC_VERSION < 2000)
 # pragma warning(pop)
 #endif
 


### PR DESCRIPTION
The warning suppression for Visual Studio 2015 is also needed for Visual Studio 2017 (_MSC_VER = 1910).