### PR TITLE
Support for AES-256-CBC with W3C padding scheme ( http://www.w3.org/2001/04/xmlenc#aes256-cbc )

### DIFF
--- a/filters.cpp
+++ b/filters.cpp
@@ -701,6 +701,7 @@ void StreamTransformationFilter::LastPut(const byte *inString, size_t length)
 
 	case PKCS_PADDING:
 	case ONE_AND_ZEROS_PADDING:
+	case W3C_PADDING:
 		unsigned int s;
 		s = m_cipher.MandatoryBlockSize();
 		CRYPTOPP_ASSERT(s > 1);
@@ -734,6 +735,13 @@ void StreamTransformationFilter::LastPut(const byte *inString, size_t length)
 				if (pad < 1 || pad > s || std::find_if(space+s-pad, space+s, std::bind2nd(std::not_equal_to<byte>(), pad)) != space+s)
 					throw InvalidCiphertext("StreamTransformationFilter: invalid PKCS #7 block padding found");
 				length = s-pad;
+			}
+			else if (m_padding == W3C_PADDING)
+			{
+				byte pad = space[s - 1];
+				if (pad < 1 || pad > s)
+					throw InvalidCiphertext("StreamTransformationFilter: invalid W3C block padding found");
+				length = s - pad;
 			}
 			else
 			{

--- a/filters.h
+++ b/filters.h
@@ -480,6 +480,8 @@ struct BlockPaddingSchemeDef
 		PKCS_PADDING,
 		//! \brief 1 and 0's padding added to a block
 		ONE_AND_ZEROS_PADDING,
+		//! \brief [Random bytes (0 ~ N-2) and padding's length (N-1)]'s padding to a block
+		W3C_PADDING,
 		//! \brief Default padding scheme
 		DEFAULT_PADDING
 	};


### PR DESCRIPTION
Quoted from:
https://github.com/readium/readium-lcp-client/pull/26#issuecomment-274689831

"
IMO, we need to consider why W3C suddenly added the padding restriction in 2002.

There was no padding details before 2002 in the W3C encryption standard. But after publishing the possibility of the Padding Oracle Attack on the block cipher algorithm in 2002, W3C had instantly updated the specification as size of the padding bytes should not be described in the padding block except last byte.

Key point of the padding oracle is that the last encrypted block before the PKCS#7 padding could be easily cracked, if the decryption program provides unnecessary error codes related padding.

So I think that not allowing using the vulnerable PCKS#7 on both server and client side is the clear way for not only consistency of the specification, but also the security perspective.
"

CC @thkim2015 @drminside