### PR TITLE
config.h: add DragonFly BSD support

### DIFF
--- a/config.h
+++ b/config.h
@@ -524,7 +524,7 @@ NAMESPACE_END
 	#define CRYPTOPP_MM_MALLOC_AVAILABLE
 #elif defined(__APPLE__)
 	#define CRYPTOPP_APPLE_MALLOC_AVAILABLE
-#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 	#define CRYPTOPP_MALLOC_ALIGNMENT_IS_16
 #elif defined(__linux__) || defined(__sun__) || defined(__CYGWIN__)
 	#define CRYPTOPP_MEMALIGN_AVAILABLE
@@ -615,7 +615,7 @@ NAMESPACE_END
 #define CRYPTOPP_UNIX_AVAILABLE
 #endif
 
-#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #define CRYPTOPP_BSD_AVAILABLE
 #endif
 


### PR DESCRIPTION
Test results attached:
[cryptopp.DragonFlyBSD.test.vectors.txt](https://github.com/weidai11/cryptopp/files/785640/cryptopp.DragonFlyBSD.test.vectors.txt)
[cryptopp.DragonFlyBSD.validation.suite.txt](https://github.com/weidai11/cryptopp/files/785641/cryptopp.DragonFlyBSD.validation.suite.txt)

**Edit**: `gcc 5.3.1 [DragonFly] Release/2015-12-04`
```
hw.model: Intel(R) Xeon(R) CPU E5-1650 v2 @ 3.50GHz
hw.machine: x86_64
hw.ncpu: 1
```