### PR TITLE
Remove unnecessary static from reference to singleton

### DIFF
--- a/osrng.cpp
+++ b/osrng.cpp
@@ -146,7 +146,7 @@ void NonblockingRng::GenerateBlock(byte *output, size_t size)
 {
 #ifdef CRYPTOPP_WIN32_AVAILABLE
 	// Acquiring a provider is expensive. Do it once and retain the reference.
-	static const MicrosoftCryptoProvider &hProvider = Singleton<MicrosoftCryptoProvider>().Ref();
+	const MicrosoftCryptoProvider &hProvider = Singleton<MicrosoftCryptoProvider>().Ref();
 # if defined(USE_MS_CRYPTOAPI)
 	if (!CryptGenRandom(hProvider.GetProviderHandle(), (DWORD)size, output))
 		throw OS_RNG_Err("CryptGenRandom");


### PR DESCRIPTION
While 46c9cc725cf325f2 fixed the static initialization problem with Visual Studio in the singleton, there is still a race condition in `NonblockingRng::GenerateBlock` (see issue #391). The reference to the singleton is still a function-level static and it will still crash if a thread enters the function while another thread is already initializing the variable. To fix this I simply removed the static from the variable.