### PR TITLE
Some fixes related to SunCC compiler bugs.

### DIFF
--- a/config.h
+++ b/config.h
@@ -204,7 +204,7 @@ typedef unsigned int word32;
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 	typedef unsigned __int64 word64;
 	#define W64LIT(x) x##ui64
-#elif (_LP64 || __LP64__) && !defined(__SUNPRO_CC)
+#elif (_LP64 || __LP64__)
 	typedef unsigned long word64;
 	#define W64LIT(x) x##UL
 #else

--- a/config.h
+++ b/config.h
@@ -204,7 +204,7 @@ typedef unsigned int word32;
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 	typedef unsigned __int64 word64;
 	#define W64LIT(x) x##ui64
-#elif (_LP64 || __LP64__)
+#elif (_LP64 || __LP64__) && !defined(__SUNPRO_CC)
 	typedef unsigned long word64;
 	#define W64LIT(x) x##UL
 #else

--- a/sha.cpp
+++ b/sha.cpp
@@ -40,7 +40,21 @@ typedef void (CRYPTOPP_FASTCALL *pfnSHAHashBlocks)(word32 *state, const word32 *
 // start of Steve Reid's code //
 ////////////////////////////////
 
-#define blk0(i) (W[i] = data[i])
+
+template <typename T>
+inline T BLK0_TEMPLATE(const T* y, const int i)
+{
+    T t;
+    memcpy(&t, y+i, sizeof(t));
+    return t;
+}
+
+#if defined(__SUNPRO_CC)
+#  define blk0(i) (W[i] = BLK0_TEMPLATE(data,i))
+#else
+#  define blk0(i) (W[i] = data[i])
+#endif
+
 #define blk1(i) (W[i&15] = rotlFixed(W[(i+13)&15]^W[(i+8)&15]^W[(i+2)&15]^W[i&15],1))
 
 #define f1(x,y,z) (z^(x&(y^z)))

--- a/vmac.cpp
+++ b/vmac.cpp
@@ -546,9 +546,23 @@ void VMAC_Base::VHASH_Update_Template(const word64 *data, size_t blocksRemaining
 	CRYPTOPP_ASSERT(IsAlignedOn(m_polyState(),GetAlignmentOf<word64>()));
 	CRYPTOPP_ASSERT(IsAlignedOn(m_nhKey(),GetAlignmentOf<word64>()));
 
-	#define INNER_LOOP_ITERATION(j)	{\
+#if defined(__SUNPRO_CC)
+	#define PREPARE_D0_D1(j) \
+		word64 d0_original = 0;\
+		memcpy(&d0_original, data + i + 2*j + 0, sizeof(d0_original));\
+		word64 d1_original = 0;\
+		memcpy(&d1_original, data + i + 2*j + 1, sizeof(d1_original));\
+		\
+		word64 d0 = ConditionalByteReverse(LITTLE_ENDIAN_ORDER, d0_original);\
+		word64 d1 = ConditionalByteReverse(LITTLE_ENDIAN_ORDER, d1_original)
+#else
+	#define PREPARE_D0_D1(j) \
 		word64 d0 = ConditionalByteReverse(LITTLE_ENDIAN_ORDER, data[i+2*j+0]);\
-		word64 d1 = ConditionalByteReverse(LITTLE_ENDIAN_ORDER, data[i+2*j+1]);\
+		word64 d1 = ConditionalByteReverse(LITTLE_ENDIAN_ORDER, data[i+2*j+1])
+#endif
+
+	#define INNER_LOOP_ITERATION(j)	{\
+		PREPARE_D0_D1(j);\
 		AccumulateNH(nhA, d0+nhK[i+2*j+0], d1+nhK[i+2*j+1]);\
 		if (T_128BitTag)\
 			AccumulateNH(nhB, d0+nhK[i+2*j+2], d1+nhK[i+2*j+3]);\

--- a/whrlpool.cpp
+++ b/whrlpool.cpp
@@ -609,7 +609,15 @@ void Whirlpool::Transform(word64 *digest, const word64 *block)
 	// Compute and apply K^0 to the cipher state
 	// Also apply part of the Miyaguchi-Preneel compression function
 	for (int i=0; i<8; i++)
+	{
+#if defined (__SUNPRO_CC)
+		word64 block_i = 0;
+		memcpy(&block_i, &block[i], sizeof(block_i));
+		digest[i] = s[i] = block_i ^ (k[i] = digest[i]);
+#else
 		digest[i] = s[i] = block[i] ^ (k[i] = digest[i]);
+#endif
+	}
 
 #define KSL(op, i, a, b, c, d)	\
 	t = (word32)k[i];\


### PR DESCRIPTION
- Fixes for "invalid address alignment" errors. See https://groups.google.com/d/topic/cryptopp-users/OYaByDEbSI0/discussion for details.
- Changed config.h in accordance to Jeffrey Walton's request;

There is still error with

```
DH validation suite running...


signal BUS (invalid address alignment) in CryptoPP::BufferedTransformation::GetMaxWaitObjectCount at line 399 in file "cryptlib.cpp"
  399           return t ? t->GetMaxWaitObjectCount() : 0;^M
```