### PR TITLE
have constant link order

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -516,7 +516,7 @@ endif # HAS_SOLIB_VERSION
 ###########################################################
 
 # List cryptlib.cpp first, then cpu.cpp, then integer.cpp to tame C++ static initialization problems.
-SRCS := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integer.cpp pch.cpp simple.cpp winpipes.cpp cryptlib_bds.cpp,$(wildcard *.cpp))
+SRCS := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integer.cpp pch.cpp simple.cpp winpipes.cpp cryptlib_bds.cpp,$(sort $(wildcard *.cpp)))
 
 # Need CPU for X86/X64/X32 and ARM
 ifeq ($(IS_X86)$(IS_X32)$(IS_X64)$(IS_ARM32)$(IS_ARM64),00000)


### PR DESCRIPTION
to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

Without this patch g++ would order functions in libcryptopp.so.5.6.5
depending on random order of files in the build system's filesystem.