### PR TITLE
Fix Windows XP support on Visual Studio 2015+

### DIFF
--- a/config.h
+++ b/config.h
@@ -44,10 +44,10 @@
 // This macro will be ignored if NO_OS_DEPENDENCE is defined.
 // #define USE_MS_CNGAPI
 
-// If the user did not make a choice, then select CryptoNG if either
-// Visual Studio 2015 is available, or Windows 10 or above is available.
+// If the user did not make a choice, then select CryptoNG if
+// targeting Windows 8 or above.
 #if !defined(USE_MS_CRYPTOAPI) && !defined(USE_MS_CNGAPI)
-# if (_MSC_VER >= 1900) || ((WINVER >= 0x0A00 /*_WIN32_WINNT_WIN10*/) || (_WIN32_WINNT >= 0x0A00 /*_WIN32_WINNT_WIN10*/))
+# if !defined(_USING_V110_SDK71_) && ((WINVER >= 0x0602 /*_WIN32_WINNT_WIN8*/) || (_WIN32_WINNT >= 0x0602 /*_WIN32_WINNT_WIN8*/))
 #  define USE_MS_CNGAPI
 # else
 #  define USE_MS_CRYPTOAPI


### PR DESCRIPTION
When compiling with Visual Studio 2015+, Crypto++ uses CryptoNG by
default. CryptoNG is only available on Windows Vista and later and
Crypto++ currently ignores if the user explicitly wants to target
Windows XP. Unlike with other Windows SDK features, everything
compiles, but the application doesn't start on Windows XP because
bcrypt.dll is missing even when setting the target Windows version correctly
at compile time. That is an issue when updating Visual Studio because the
root cause is hard to find.

Making use of CryptoNG when targeting Windows 8+ instead by default,
regardless of the Visual Studio version, to fix this.
(Using Windows 8 rather than Windows 10 because "Modern" Windows Apps
need to target at least Windows 8 and it's not possible to accidently target
Windows 8+ when building applications supporting Windows XP)