### PR TITLE
sockets: fix Windows 2000 build

### DIFF
--- a/socketft.cpp
+++ b/socketft.cpp
@@ -30,8 +30,11 @@
 # include <sanitizer/msan_interface.h>
 #endif
 
-#ifdef PREFER_WINDOWS_STYLE_SOCKETS
+#ifdef USE_WINDOWS_STYLE_SOCKETS
 # pragma comment(lib, "ws2_32.lib")
+# if defined(_WIN32_WINNT) && (_WIN32_WINNT < 0x501)
+#  include <wspiapi.h>
+# endif
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)


### PR DESCRIPTION
Commit 4630a5dab66a0e18ec8dfc0998ac223e40b3dc13 broke compilation for
Windows 2000 and earlier as getaddrinfo was introduced in Windows XP.
Fix this by including <wspiapi.h> when targeting Windows 2000 and
earlier, which falls back to an inline implementation of getaddrinfo
when necessary.
Some MinGW flavors still target Windows 2000 by default.

Ref:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms738520.aspx,
section "Support for getaddrinfo on Windows 2000 and older versions"