### PR TITLE
SSE align SecBlocks on i386 and x86_64

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -826,7 +826,7 @@ convert:
 	@-$(CHMOD) 0700 $(EXEC_FILES) *.sh *.cmd TestScripts/*.sh TestScripts/*.pl TestScripts/*.cmd
 	@-$(CHMOD) 0700 *.cmd *.sh GNUmakefile GNUmakefile-cross TestScripts/*.sh TestScripts/*.pl
 	-unix2dos --keepdate --quiet $(TEXT_FILES) .*.yml *.asm *.cmd *.cmake TestScripts/*.*
-	-dos2unix --keepdate --quiet GNUmakefile GNUmakefile-cross *.s *.sh TestScripts/*.sh
+	-dos2unix --keepdate --quiet GNUmakefile GNUmakefile-cross *.s *.sh *.mapfile TestScripts/*.sh
 ifneq ($(IS_DARWIN),0)
 	@-xattr -c *
 endif

--- a/config.h
+++ b/config.h
@@ -470,6 +470,7 @@ NAMESPACE_END
 	#define CRYPTOPP_X64_ASM_AVAILABLE 1
 #endif
 
+// 32-bit SunCC does not enable SSE2 by default.
 #if !defined(CRYPTOPP_DISABLE_ASM) && (defined(_MSC_VER) || defined(__SSE2__))
 	#define CRYPTOPP_SSE2_INTRIN_AVAILABLE 1
 #endif
@@ -498,8 +499,14 @@ NAMESPACE_END
 	#define CRYPTOPP_SSE42_AVAILABLE 1
 #endif
 
-// Requires Sun Studio 12.3 (SunCC 0x5120)
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_CLMUL) && \
+// Couple to CRYPTOPP_DISABLE_AES, but use CRYPTOPP_CLMUL_AVAILABLE so we can selectively
+//  disable for misbehaving platofrms and compilers, like Solaris or some Clang.
+#if defined(CRYPTOPP_DISABLE_AES)
+	#define CRYPTOPP_DISABLE_CLMUL 1
+#endif
+
+// Requires Sun Studio 12.3 (SunCC 0x5120) in theory.
+#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_CLMUL) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
 	(defined(__PCLMUL__) || (_MSC_FULL_VER >= 150030729) || (__SUNPRO_CC >= 0x5120) || \
 	(CRYPTOPP_GCC_VERSION >= 40300) || (__INTEL_COMPILER >= 1110) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 30200) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300))
@@ -507,7 +514,7 @@ NAMESPACE_END
 #endif
 
 // Requires Sun Studio 12.3 (SunCC 0x5120)
-#if !defined(CRYPTOPP_DISABLE_SSE4) && defined(CRYPTOPP_SSSE3_AVAILABLE) && \
+#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_AES) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
 	(defined(__AES__) || (_MSC_FULL_VER >= 150030729) || (__SUNPRO_CC >= 0x5120) || \
 	(CRYPTOPP_GCC_VERSION >= 40300) || (__INTEL_COMPILER >= 1110) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 30200) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300))
@@ -575,7 +582,8 @@ NAMESPACE_END
 
 // ***************** Miscellaneous ********************
 
-#if CRYPTOPP_SSE2_INTRIN_AVAILABLE || CRYPTOPP_SSE2_ASM_AVAILABLE || defined(CRYPTOPP_X64_MASM_AVAILABLE)
+// Nearly all Intel's and AMD's have SSE. Enable it independent of SSE ASM and intrinscs
+#if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64) && !defined(CRYPTOPP_DISABLE_ASM)
 	#define CRYPTOPP_BOOL_ALIGN16 1
 #else
 	#define CRYPTOPP_BOOL_ALIGN16 0

--- a/cryptest.mapfile
+++ b/cryptest.mapfile
@@ -1,1 +1,3 @@
+# Solaris mapfile to override hardware caps to avoid kills
+
 hwcap_1 = SSE SSE2 OVERRIDE;

--- a/secblock.h
+++ b/secblock.h
@@ -220,7 +220,7 @@ public:
 		SecureWipeArray((pointer)ptr, size);
 
 #if CRYPTOPP_BOOL_ALIGN16
-		if (T_Align16 && size*sizeof(T) >= 16)
+		if (T_Align16 && size)
 			return AlignedDeallocate(ptr);
 #endif
 
@@ -242,7 +242,7 @@ public:
 		SecureWipeArray((pointer)ptr, STDMIN(size, mark));
 
 #if CRYPTOPP_BOOL_ALIGN16
-		if (T_Align16 && size*sizeof(T) >= 16)
+		if (T_Align16 && size)
 			return AlignedDeallocate(ptr);
 #endif
 

--- a/secblock.h
+++ b/secblock.h
@@ -199,7 +199,7 @@ public:
 
 #if CRYPTOPP_BOOL_ALIGN16
 		// TODO: should this need the test 'size*sizeof(T) >= 16'?
-		if (T_Align16 && size*sizeof(T) >= 16)
+		if (T_Align16 && size)
 			return (pointer)AlignedAllocate(size*sizeof(T));
 #endif
 


### PR DESCRIPTION
Since moving to split sources (base+simd) we found SecBlocks declared in headers may not be 16-byte aligned because the architecture switch is present on the simd file, and not the base file.

16-byte aligned is the default for most systems nowadays, so we side stepped alignment problems on all platforms except 32-bit Solaris. We need the 16-byte alignment for all Intel compatibles since the late 1990s, which is nearly all processors in the class.

The worst case is, if a processor lacks SSE2, then it gets an aligned SecBlock anyways. The last time we saw processors without the features was 486 and early Pentiums, and that was 1996 or so. Even low-end processors like Intel Atoms and VIA have SSE2+SSSE3.

Also see "Enable 16-byte alignment full-time for i386 and x86_64?" (https://groups.google.com/forum/#!topic/cryptopp-users/ubp-gFC1BJI) for a discussion