### PR TITLE
Fix compilation of secblock.h under Visual Studio 2010.

### DIFF
--- a/secblock.h
+++ b/secblock.h
@@ -56,7 +56,7 @@ public:
 	//! \since Crypto++ 6.0
 #if defined(CRYPTOPP_DOXYGEN_PROCESSING)
 	static const size_type ELEMS_MAX = ...;
-#elif defined(CRYPTOPP_CXX11)
+#elif defined(CRYPTOPP_CXX11_ENUM)
 	enum : size_type {ELEMS_MAX = SIZE_MAX/sizeof(T)};
 #else
 	static const size_type ELEMS_MAX = SIZE_MAX/sizeof(T);


### PR DESCRIPTION
Fix compilation of secblock.h under Visual Studio 2010 (which only has partial C++ 2011 support).

This fixes issue #475 .