### PR TITLE
Remove WORKAROUND_MS_BUG_Q258000 from the config and osrng.

### DIFF
--- a/config.h
+++ b/config.h
@@ -145,11 +145,6 @@
 #	error namespace support is now required
 #endif
 
-// Define this to workaround a Microsoft CryptoAPI bug where
-// each call to CryptAcquireContext causes a 100 KB memory leak.
-// Defining this will cause Crypto++ to make only one call to CryptAcquireContext.
-#define WORKAROUND_MS_BUG_Q258000
-
 #ifdef CRYPTOPP_DOXYGEN_PROCESSING
 // Document the namespce exists. Put it here before CryptoPP is undefined below.
 //! \namespace CryptoPP

--- a/osrng.h
+++ b/osrng.h
@@ -35,7 +35,7 @@ public:
 #ifdef CRYPTOPP_WIN32_AVAILABLE
 //! \class MicrosoftCryptoProvider
 //! \brief Wrapper for Microsoft crypto service provider
-//! \sa \def USE_MS_CRYPTOAPI, \def USE_MS_CNGAPI, \def WORKAROUND_MS_BUG_Q258000
+//! \sa \def USE_MS_CRYPTOAPI, \def USE_MS_CNGAPI
 class CRYPTOPP_DLL MicrosoftCryptoProvider
 {
 public:


### PR DESCRIPTION
Remove WORKAROUND_MS_BUG_Q258000 from the config and osrng. Firstly, it's no longer used anywhere. Next, when it was used, that workaround only applied to versions of Windows prior to Windows 2000. I.e. ancient, unsecure, unused versions of Windows.

In fact, googling that "Q258000" reference number no longer returns any results because Microsoft has long since removed references to the now outdated bug.