### PR TITLE
Fix build on FreeBSD 10.3 x86 with clang++ 3.4.1.

### DIFF
--- a/sha.cpp
+++ b/sha.cpp
@@ -43,7 +43,8 @@
 
 // Clang 3.3 integrated assembler crash on Linux
 //  http://github.com/weidai11/cryptopp/issues/264
-#if defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30400)
+// Clang 3.4.1 (x86) crash on FreeBSD 10.3. Clang 3.4.1 (x64) works fine.
+#if defined(CRYPTOPP_LLVM_CLANG_VERSION) && ((CRYPTOPP_LLVM_CLANG_VERSION < 30400) || CRYPTOPP_BOOL_X86 && (CRYPTOPP_LLVM_CLANG_VERSION < 30500))
 # define CRYPTOPP_DISABLE_SHA_ASM
 #endif
 

--- a/sha.cpp
+++ b/sha.cpp
@@ -44,7 +44,7 @@
 // Clang 3.3 integrated assembler crash on Linux
 //  http://github.com/weidai11/cryptopp/issues/264
 // Clang 3.4.1 (x86) crash on FreeBSD 10.3. Clang 3.4.1 (x64) works fine.
-#if defined(CRYPTOPP_LLVM_CLANG_VERSION) && ((CRYPTOPP_LLVM_CLANG_VERSION < 30400) || CRYPTOPP_BOOL_X86 && (CRYPTOPP_LLVM_CLANG_VERSION < 30500))
+#if defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30500)
 # define CRYPTOPP_DISABLE_SHA_ASM
 #endif
 


### PR DESCRIPTION
Fix build on FreeBSD 10.3 x86 with clang++ 3.4.1. The x64 build (also clang++ 3.4.1) doesn't require `CRYPTOPP_DISABLE_SHA_ASM`. It seems to be a bug specific to the x86 version of clang++.

```
clang++ -m32 -v
```

Returns the following:

```
FreeBSD clang version 3.4.1 (tags/RELEASE_34/dot1-final 208032) 20140512
Target: i386-unknown-freebsd10.3
Thread model: posix
Selected GCC installation: 
```

Also, this patch assumes this bug is fixed in clang++ (x86) 3.5. I don't actually know if that's true. But I figure it's better to version limit the disabling of the assembly, rather than always disabling the sha ASM for all x86 clang versions.