### PR TITLE
Make the debug build more closely behave like release if `CRYPTOPP_NO_TESTS` is defined.

### DIFF
--- a/3way.cpp
+++ b/3way.cpp
@@ -7,7 +7,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void ThreeWay_TestInstantiations()
 {
 	ThreeWay::Encryption x1;

--- a/arc4.cpp
+++ b/arc4.cpp
@@ -13,7 +13,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 namespace Weak1 {
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void ARC4_TestInstantiations()
 {
 	ARC4 x;

--- a/chacha.cpp
+++ b/chacha.cpp
@@ -17,7 +17,7 @@ NAMESPACE_BEGIN(CryptoPP)
     a += b; d ^= a; d = rotlFixed<word32>(d, 8); \
     c += d; b ^= c; b = rotlFixed<word32>(b, 7);
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void ChaCha_TestInstantiations()
 {
 	 ChaCha8::Encryption x1;

--- a/config.h
+++ b/config.h
@@ -137,6 +137,12 @@
 # define CRYPTOPP_DEBUG 1
 #endif
 
+// CRYPTOPP_TEST_INSTANTIATIONS enables the class instantiation tests
+//   in each encryption source. For example, RSA_TestInstantiations().
+#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING) && !defined(CRYPTOPP_NO_TESTS)
+# define CRYPTOPP_TEST_INSTANTIATIONS 1
+#endif
+
 // ***************** Important Settings Again ********************
 // But the defaults should be ok.
 

--- a/dh.cpp
+++ b/dh.cpp
@@ -8,7 +8,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void DH_TestInstantiations()
 {
 	DH dh1;

--- a/dh2.cpp
+++ b/dh2.cpp
@@ -7,7 +7,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 struct NullCryptoParameters : public CryptoParameters
 {
 	void AssignFrom(const NameValuePairs &source) {

--- a/eccrypto.cpp
+++ b/eccrypto.cpp
@@ -31,7 +31,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 
 #if 0
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 static void ECDSA_TestInstantiations()
 {
 	ECDSA<EC2N>::Signer t1;

--- a/elgamal.cpp
+++ b/elgamal.cpp
@@ -7,7 +7,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void ElGamal_TestInstantiations()
 {
 	ElGamalEncryptor test1(1, 1, 1);

--- a/esign.cpp
+++ b/esign.cpp
@@ -18,7 +18,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void ESIGN_TestInstantiations()
 {
 	ESIGN<SHA1>::Verifier x1(1, 1);

--- a/files.cpp
+++ b/files.cpp
@@ -10,7 +10,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void Files_TestInstantiations()
 {
 	FileStore f0;

--- a/gfpcrypt.cpp
+++ b/gfpcrypt.cpp
@@ -20,7 +20,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void TestInstantiations_gfpcrypt()
 {
 	GDSA<SHA1>::Signer test;

--- a/integer.cpp
+++ b/integer.cpp
@@ -2712,7 +2712,7 @@ static inline void AtomicDivide(word *Q, const word *A, const word *B)
 		Q[1] = SubatomicDivide(T+1, B[0], B[1]);
 		Q[0] = SubatomicDivide(T, B[0], B[1]);
 
-#if defined(CRYPTOPP_DEBUG)
+#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_NO_TESTS)
 		// multiply quotient and divisor and add remainder, make sure it equals dividend
 		CRYPTOPP_ASSERT(!T[2] && !T[3] && (T[1] < B[1] || (T[1]==B[1] && T[0]<B[0])));
 		word P[4];
@@ -2731,7 +2731,7 @@ static inline void AtomicDivide(word *Q, const word *A, const word *B)
 	Q[0] = q.GetLowHalf();
 	Q[1] = q.GetHighHalf();
 
-#if defined(CRYPTOPP_DEBUG)
+#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_NO_TESTS)
 	if (B[0] || B[1])
 	{
 		// multiply quotient and divisor and add remainder, make sure it equals dividend

--- a/luc.cpp
+++ b/luc.cpp
@@ -11,7 +11,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void LUC_TestInstantiations()
 {
 	LUC_HMP<SHA1>::Signer t1;

--- a/md5.cpp
+++ b/md5.cpp
@@ -9,7 +9,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 namespace Weak1 {
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void MD5_TestInstantiations()
 {
 	MD5 x;

--- a/modes.cpp
+++ b/modes.cpp
@@ -7,13 +7,13 @@
 #include "modes.h"
 #include "misc.h"
 
-#if defined(CRYPTOPP_DEBUG)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 #include "des.h"
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void Modes_TestInstantiations()
 {
 	CFB_Mode<DES>::Encryption m0;

--- a/mqv.cpp
+++ b/mqv.cpp
@@ -9,7 +9,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void TestInstantiations_MQV()
 {
 	MQV mqv;

--- a/rsa.cpp
+++ b/rsa.cpp
@@ -11,7 +11,7 @@
 #include "fips140.h"
 #include "pkcspad.h"
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING) && !defined(CRYPTOPP_IS_DLL)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 #include "pssr.h"
 NAMESPACE_BEGIN(CryptoPP)
 void RSA_TestInstantiations()

--- a/salsa.cpp
+++ b/salsa.cpp
@@ -30,7 +30,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void Salsa20_TestInstantiations()
 {
 	Salsa20::Encryption x1;

--- a/seal.cpp
+++ b/seal.cpp
@@ -11,7 +11,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void SEAL_TestInstantiations()
 {
 	SEAL<>::Encryption x;

--- a/wake.cpp
+++ b/wake.cpp
@@ -7,7 +7,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void WAKE_TestInstantiations()
 {
 	WAKE_OFB<>::Encryption x2;

--- a/whrlpool.cpp
+++ b/whrlpool.cpp
@@ -83,7 +83,7 @@
 
 NAMESPACE_BEGIN(CryptoPP)
 
-#if defined(CRYPTOPP_DEBUG) && !defined(CRYPTOPP_DOXYGEN_PROCESSING)
+#if defined(CRYPTOPP_TEST_INSTANTIATIONS)
 void Whirlpool_TestInstantiations()
 {
 	Whirlpool x;


### PR DESCRIPTION
This commit makes it possible to make the debug build more closely behave like the release build if `CRYPTOPP_NO_TESTS` is defined.

This solves build errors if you're building the debug version of the library but don't include all of the library's functionality. For example, we use RSA but don't use PSSR. However, when using the debug version of the library (and excluding the PSSR source) we run into errors like:

```
Error	LNK2001	unresolved external symbol "private: virtual unsigned __int64 __cdecl CryptoPP::PSSR_MEM_Base::MinRepresentativeBitLength(unsigned __int64,unsigned __int64)const " (?MinRepresentativeBitLength@PSSR_MEM_Base@CryptoPP@@EEBA_K_K0@Z)
```


The other added advantage is that the debug build will now more closely match the release build (and thus reduce chance for debug/release discrepancies making bug tracking more difficult).


This change also preserves the default behavior to always build in those tests on debug builds. The user explicitly has to define `CRYPTOPP_NO_TESTS`.