### PR TITLE
Fix missing header for Android CPU features

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -18,6 +18,10 @@
 # include <setjmp.h>
 #endif
 
+#if defined(__ANDROID__)
+# include <cpu-features.h>
+#endif
+
 NAMESPACE_BEGIN(CryptoPP)
 
 #ifndef CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY


### PR DESCRIPTION
Calls to `android_getCpuFeatures()` require that you `#include <cpu-features.h>` per documentation at https://developer.android.com/ndk/guides/cpu-features.html . This pull request simply adds the required include header in `cpu.cpp`.

Edit: This fixed a compile bug using `ndk-build` that I was running into.