### PR TITLE
RFC: workarounds for original MinGW

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,6 +46,7 @@ IS_SUN := $(shell uname -s | $(GREP) -i -c "SunOS")
 
 IS_LINUX := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -i -c "Linux")
 IS_MINGW := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -i -c "MinGW")
+IS_MINGW32 := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -x -c "mingw32")
 IS_CYGWIN := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -i -c "Cygwin")
 IS_DARWIN := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -i -c "Darwin")
 IS_NETBSD := $(shell $(CXX) -dumpmachine 2>/dev/null | $(GREP) -i -c "NetBSD")
@@ -152,6 +153,20 @@ endif
 
 # Clang integrated assembler will be used with -Wa,-q
 CLANG_INTEGRATED_ASSEMBLER ?= 0
+
+# original MinGW targets Win2k by default, but lacks proper Win2k support
+# if target Windows version is not specified, use Windows XP instead
+ifeq ($(IS_MINGW32),1)
+ifeq ($(findstring -D_WIN32_WINNT,$(CXXFLAGS)),)
+ifeq ($(findstring -D_WIN32_WINDOWS,$(CXXFLAGS)),)
+ifeq ($(findstring -DWINVER,$(CXXFLAGS)),)
+ifeq ($(findstring -DNTDDI_VERSION,$(CXXFLAGS)),)
+  CXXFLAGS += -D_WIN32_WINNT=0x0501
+endif # NTDDI_VERSION
+endif # WINVER
+endif # _WIN32_WINDOWS
+endif # _WIN32_WINNT
+endif # IS_MINGW32
 
 ###########################################################
 #####               X86/X32/X64 Options               #####

--- a/config.h
+++ b/config.h
@@ -942,7 +942,15 @@ NAMESPACE_END
 #if (CRYPTOPP_MSC_VERSION >= 1700) || (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || \
 	(CRYPTOPP_APPLE_CLANG_VERSION >= 50000) || (__INTEL_COMPILER >= 1200) || \
 	(CRYPTOPP_GCC_VERSION >= 40400) || (__SUNPRO_CC >= 0x5130)
-# define CRYPTOPP_CXX11_SYNCHRONIZATION 1
+// Hack ahead. New GCC compilers like GCC 6 on AIX 7.0 or earlier as well as original MinGW
+// don't have the synchronization gear. However, Wakely's test used for Apple does not work
+// on the GCC/AIX combination. Another twist is we need other stuff from C++11,
+// like no-except destructors. Dumping preprocessors shows the following may
+// apply: http://stackoverflow.com/q/14191566/608639.
+# include <cstddef>
+# if !defined(__GLIBCXX__) || defined(_GLIBCXX_HAS_GTHREADS)
+#  define CRYPTOPP_CXX11_SYNCHRONIZATION 1
+# endif
 #endif // synchronization
 
 // Dynamic Initialization and Destruction with Concurrency ("Magic Statics")
@@ -1002,17 +1010,6 @@ NAMESPACE_END
 // TODO: Emplacement, R-values and Move semantics
 
 #endif // CRYPTOPP_CXX11
-
-// Hack ahead. New GCC compilers like GCC 6 on AIX 7.0 or earlier don't have the
-//   synchronization gear. However, Wakely's test used for Apple does not work
-//   on the GCC/AIX combination. Another twist is we need other stuff from C++11,
-//   like no-except destructors. Dumping preprocessors shows the following may
-//   apply: http://stackoverflow.com/q/14191566/608639.
-#if defined(_AIX) && defined(__GNUC__)
-#  if !defined(_GLIBCXX_HAS_GTHREADS)
-#    undef CRYPTOPP_CXX11_SYNCHRONIZATION
-#  endif
-#endif
 
 #if defined(CRYPTOPP_CXX11_NOEXCEPT)
 #  define CRYPTOPP_THROW noexcept(false)


### PR DESCRIPTION
- set default target Windows version to Windows XP instead of 2000 in the makefile
- if `_GLIBCXX_HAS_GTHREADS` is not defined, libstc++ doesn't provide `std::mutex` - unfortunately, the header usually used for standard library detection, `<ciso646>`, has recently been proposed to be removed from C++20 [1], so I chose `<cstddef>` instead in hopes that it would get included anyway

[1] https://wg21.link/P0619
