### PR TITLE
Add pkgconfig file libcrypt++.pc

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -840,6 +840,10 @@ install:
 	$(CP) *.h $(DESTDIR)$(INCLUDEDIR)/cryptopp
 	-$(CHMOD) 0755 $(DESTDIR)$(INCLUDEDIR)/cryptopp
 	-$(CHMOD) 0644 $(DESTDIR)$(INCLUDEDIR)/cryptopp/*.h
+	@-$(MKDIR) -p $(DESTDIR)$(LIBDIR)/pkgconfig
+	$(CP) libcrypto++.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+	-$(CHMOD) 0755 $(DESTDIR)$(LIBDIR)/pkgconfig
+	-$(CHMOD) 0644 $(DESTDIR)$(LIBDIR)/pkgconfig/libcrypto++.pc
 ifneq ($(wildcard libcryptopp.a),)
 	@-$(MKDIR) -p $(DESTDIR)$(LIBDIR)
 	$(CP) libcryptopp.a $(DESTDIR)$(LIBDIR)

--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -354,6 +354,10 @@ install:
 	$(CP) *.h $(DESTDIR)$(INCLUDEDIR)/cryptopp
 	-$(CHMOD) 755 $(DESTDIR)$(INCLUDEDIR)/cryptopp
 	-$(CHMOD) 644 $(DESTDIR)$(INCLUDEDIR)/cryptopp/*.h
+	@-$(MKDIR) -p $(DESTDIR)$(LIBDIR)/pkgconfig
+	$(CP) libcrypto++.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+	-$(CHMOD) 755 $(DESTDIR)$(LIBDIR)/pkgconfig
+	-$(CHMOD) 644 $(DESTDIR)$(LIBDIR)/pkgconfig/libcrypto++.pc
 ifneq ($(wildcard cryptest.exe),)
 	$(MKDIR) -p $(DESTDIR)$(BINDIR)
 	$(CP) cryptest.exe $(DESTDIR)$(BINDIR)

--- a/libcrypto++.pc
+++ b/libcrypto++.pc
@@ -1,0 +1,9 @@
+prefix=/usr
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libcrypto++
+Description: Class library of cryptographic schemes
+Version: 6.0.0
+Libs: -L${libdir} -lcryptopp
+Cflags: -I${includedir}


### PR DESCRIPTION
This is used by pkgconfig to know which build and link flags should be
used when compiling against crypto++.

One issue is that the version is hard-coded in the pkgconfig file.

Ideally, we would generate this file with the right version when building.