### PR TITLE
Change ::log() to log() to work with C++Builder

### DIFF
--- a/bench1.cpp
+++ b/bench1.cpp
@@ -70,7 +70,7 @@ void OutputResultBytes(const char *name, double length, double timeTaken)
 		else
 			std::cout << "<TD>" << std::setprecision(1) << std::setiosflags(std::ios::fixed) << cpb;
 	}
-	g_logTotal += ::log(mbs);
+	g_logTotal += log(mbs);
 	g_logCount++;
 }
 
@@ -109,7 +109,7 @@ void OutputResultOperations(const char *name, const char *operation, bool pc, un
 		std::cout << "<TD>" << std::setprecision(2) << std::setiosflags(std::ios::fixed) << t;
 	}
 
-	g_logTotal += ::log(iterations/timeTaken);
+	g_logTotal += log(iterations/timeTaken);
 	g_logCount++;
 }
 

--- a/nbtheory.cpp
+++ b/nbtheory.cpp
@@ -1021,14 +1021,14 @@ unsigned int FactoringWorkFactor(unsigned int n)
 	// extrapolated from the table in Odlyzko's "The Future of Integer Factorization"
 	// updated to reflect the factoring of RSA-130
 	if (n<5) return 0;
-	else return (unsigned int)(2.4 * std::pow((double)n, 1.0/3.0) * std::pow(::log(double(n)), 2.0/3.0) - 5);
+	else return (unsigned int)(2.4 * std::pow((double)n, 1.0/3.0) * std::pow(log(double(n)), 2.0/3.0) - 5);
 }
 
 unsigned int DiscreteLogWorkFactor(unsigned int n)
 {
 	// assuming discrete log takes about the same time as factoring
 	if (n<5) return 0;
-	else return (unsigned int)(2.4 * std::pow((double)n, 1.0/3.0) * std::pow(::log(double(n)), 2.0/3.0) - 5);
+	else return (unsigned int)(2.4 * std::pow((double)n, 1.0/3.0) * std::pow(log(double(n)), 2.0/3.0) - 5);
 }
 
 // ********************************************************

--- a/stdcpp.h
+++ b/stdcpp.h
@@ -62,4 +62,10 @@ namespace std {
 # include <vector.cc>
 #endif
 
+// C++Builder's standard library (Dinkumware) do not have C's global log() function
+// https://github.com/weidai11/cryptopp/issues/520
+#ifdef __BORLANDC__
+using std::log;
+#endif
+
 #endif


### PR DESCRIPTION
As reported in #520, C++Builder standard libraries don't have a `log()` function at global namespace. Change the invocations to unqualified name lookup, and apply a using-declaration to `std::log()` when compiling under C++Builder.