### PR TITLE
Deterministic k (RFC6979): issue in bits2octets and new test case

### DIFF
--- a/gfpcrypt.h
+++ b/gfpcrypt.h
@@ -384,7 +384,7 @@ protected:
     // curve's order.
     SecByteBlock bits2octets(const SecByteBlock& in, const Integer& q) const
     {
-        Integer b2 = bits2int(in, in.size()*8);
+        Integer b2 = bits2int(in, q.BitCount());
         Integer b1 = b2 - q;
         return int2octets(b1.IsNegative() ? b2 : b1, q.ByteCount());
     }

--- a/validat1.cpp
+++ b/validat1.cpp
@@ -201,6 +201,7 @@ bool ValidateAll(bool thorough)
 	pass=ValidateECP() && pass;
 	pass=ValidateEC2N() && pass;
 	pass=ValidateECDSA() && pass;
+	pass=ValidateECDSA_RFC6979() && pass;
 	pass=ValidateECGDSA(thorough) && pass;
 	pass=ValidateESIGN() && pass;
 

--- a/validat2.cpp
+++ b/validat2.cpp
@@ -995,6 +995,26 @@ bool ValidateECDSA()
 	return pass;
 }
 
+bool ValidateECDSA_RFC6979() 
+{ 
+	std::cout << "\nRFC6979 deterministic ECDSA validation suite running...\n\n"; 
+	
+	DL_Algorithm_ECDSA_RFC6979<ECP, SHA256> sign; 
+	
+	const Integer x("09A4D6792295A7F730FC3F2B49CBC0F62E862272Fh"); 
+	const Integer e("AF2BDBE1AA9B6EC1E2ADE1D694F41FC71A831D0268E9891562113D8A62ADD1BFh"); 
+	const Integer q("4000000000000000000020108A2E0CC0D99F8A5EFh"); 
+	const Integer k("23AF4074C90A02B3FE61D286D5C87F425E6BDD81Bh"); 
+	const auto k_out = sign.GenerateRandom(x, q, e); 
+	
+	bool pass  = (k_out == k); 
+	
+	std::cout << (!pass ? "FAILED    " : "passed    ");
+	std::cout << "deterministic k generation against test vector\n";
+	
+	return pass;
+}
+
 // from http://www.teletrust.de/fileadmin/files/oid/ecgdsa_final.pdf
 bool ValidateECGDSA(bool thorough)
 {

--- a/validate.h
+++ b/validate.h
@@ -106,6 +106,7 @@ bool ValidateRW();
 bool ValidateECP();
 bool ValidateEC2N();
 bool ValidateECDSA();
+bool ValidateECDSA_RFC6979();
 bool ValidateECGDSA(bool thorough);
 bool ValidateESIGN();
 


### PR DESCRIPTION
I have been experimenting with ECDSA_RFC6979 by feeding data from the original RFC-6979 ([section A.1.2](https://tools.ietf.org/html/rfc6979#appendix-A.1.2)). The result calculated by DL_Algorithm_ECDSA_RFC6979::GenerateRandom does not agree with the one given by the RFC.

I have created a unit test case (see 'ValidateECDSA_RFC6979' in diff), using the same data given by the RFC. It currently fails with the latest code.

It seems to me the problem is in bits2octets. Specifically, when it calls bits2int, according to RFC [section 2.3.2](https://tools.ietf.org/html/rfc6979#section-2.3.2), the bit count should be that of the base point (i.e. "q", in order to "shrink" the hash value). The current code uses the hash value's bit count. 

By changing the bit count to q.BitCount(), the new unit test case passes - the generated "k" matches the RFC's value.