### PR TITLE
Fix building for Linuxbrew

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -60,8 +60,10 @@ INTEL_COMPILER := $(shell $(CXX) --version 2>/dev/null | $(GREP) -i -c '\(icc\)'
 # Various Port compilers on OS X
 MACPORTS_COMPILER := $(shell $(CXX) --version 2>/dev/null | $(GREP) -i -c "macports")
 HOMEBREW_COMPILER := $(shell $(CXX) --version 2>/dev/null | $(GREP) -i -c "homebrew")
-ifneq ($(MACPORTS_COMPILER)$(HOMEBREW_COMPILER),00)
-  OSXPORT_COMPILER := 1
+ifeq ($(IS_DARWIN),1)
+  ifneq ($(MACPORTS_COMPILER)$(HOMEBREW_COMPILER),00)
+    OSXPORT_COMPILER := 1
+  endif
 endif
 
 # Sun Studio 12.0 provides SunCC 0x0510; and Sun Studio 12.3 provides SunCC 0x0512


### PR DESCRIPTION
Linuxbrew is a fork of Homebrew on Linux. In which, the `gcc --version` will report "homebrew". Therefore, the current code will incorrectly set `OSXPORT_COMPILER` under such environment, which results to the following compiling errors:

<details>
<summary> Log </summary>

```
gcm.cpp:823: Error: too many memory references for `add'
gcm.cpp:824: Error: too many memory references for `pxor'
gcm.cpp:825: Error: ambiguous operand size for `shr'
gcm.cpp:826: Error: too many memory references for `movzx'
gcm.cpp:827: Error: too many memory references for `add'
gcm.cpp:828: Error: too many memory references for `pxor'
gcm.cpp:829: Error: too many memory references for `movzx'
gcm.cpp:830: Error: too many memory references for `add'
gcm.cpp:831: Error: too many memory references for `pxor'
gcm.cpp:832: Error: ambiguous operand size for `add'
gcm.cpp:833: Error: ambiguous operand size for `sub'
gcm.cpp:835: Error: too many memory references for `movdqa'
g++-5 -DNDEBUG -g2 -O3 -fPIC -Wa,-q -DCRYPTOPP_CLANG_INTEGRATED_ASSEMBLER=1 -pthread -pipe -c md4.cpp
make: *** [GNUmakefile:1120: gcm.o] Error 1
make: *** Waiting for unfinished jobs....
```
</details>
</br>

Fix this problem by checking `IS_DARWIN` before setting `OSXPORT_COMPILER`.