### PR TITLE
build: add missing flags for SIMON and SPECK in GNUMakefile-cross

### DIFF
--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -220,12 +220,16 @@ ifeq ($(IS_NEON),1)
     GCM_FLAG += -mfpu=neon
     ARIA_FLAG += -mfpu=neon
     BLAKE2_FLAG += -mfpu=neon
+    SIMON_FLAG += -mfpu=neon
+    SPECK_FLAG += -mfpu=neon
     ifeq ($(IS_ANDROID),1)
       ifeq ($(findstring -mfloat-abi=softfp,$(CXXFLAGS)),)
         NEON_FLAG += -mfloat-abi=softfp
         GCM_FLAG += -mfloat-abi=softfp
         ARIA_FLAG += -mfloat-abi=softfp
         BLAKE2_FLAG += -mfloat-abi=softfp
+        SIMON_FLAG += -mfloat-abi=softfp
+        SPECK_FLAG += -mfloat-abi=softfp
       endif
     endif
   endif
@@ -238,6 +242,8 @@ ifneq ($(IS_ARMv8),0)
     ARIA_FLAG = -march=armv8-a
     BLAKE2_FLAG = -march=armv8-a
     NEON_FLAG = -march=armv8-a
+    SIMON_FLAG = -march=armv8-a
+    SPECK_FLAG = -march=armv8-a
   endif
   HAVE_CRC := $(shell echo | $(CXX) -x c++ $(CXXFLAGS) -march=armv8-a+crc -dM -E - 2>/dev/null | $(EGREP) -i -c __ARM_FEATURE_CRC32)
   ifeq ($(HAVE_CRC),1)
@@ -257,6 +263,13 @@ ifneq ($(IS_i686)$(IS_x86_64),00)
   ifeq ($(HAVE_SSSE3),1)
     ARIA_FLAG = -mssse3
     SSSE3_FLAG = -mssse3
+    SIMON_FLAG = -mssse3
+    SPECK_FLAG = -mssse3
+  endif
+  HAVE_SSE4 = $(shell echo | $(CXX) -x c++ $(CXXFLAGS) -msse4.1 -dM -E - 2>/dev/null | $(EGREP) -i -c __SSE4_1__)
+  ifeq ($(HAVE_SSE4),1)
+    SIMON_FLAG = -msse4.1
+    SPECK_FLAG = -msse4.1
   endif
   HAVE_SSE4 = $(shell echo | $(CXX) -x c++ $(CXXFLAGS) -msse4.2 -dM -E - 2>/dev/null | $(EGREP) -i -c __SSE4_2__)
   ifeq ($(HAVE_SSE4),1)
@@ -479,6 +492,14 @@ sha-simd.o : sha-simd.cpp
 # SSE4.2/SHA-NI or ARMv8a available
 shacal2-simd.o : shacal2-simd.cpp
 	$(CXX) $(strip $(CXXFLAGS) $(SHA_FLAG) -c) $<
+
+# SSSE3 or NEON available
+simon-simd.o : simon-simd.cpp
+	$(CXX) $(strip $(CXXFLAGS) $(SIMON_FLAG) -c) $<
+
+# SSSE3 or NEON available
+speck-simd.o : speck-simd.cpp
+	$(CXX) $(strip $(CXXFLAGS) $(SPECK_FLAG) -c) $<
 
 %.o : %.cpp
 	$(CXX) $(strip $(CXXFLAGS) -c) $<


### PR DESCRIPTION
This fixes build on Arch Linux.  The relevant bits were simply copied from GNUMakefile.