### PR TITLE
RNG tuneup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,13 @@ local.properties
 
 [Dd]ebug/
 [Rr]elease/
+Win32/
 x64/
 build/
 [Bb]in/
 [Oo]bj/
 [Ll]ibs/
+.vs/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
@@ -106,6 +108,7 @@ build/
 *.tmp
 *.tmp_proj
 *.log
+# *.tlog
 *.vspscc
 *.vssscc
 .builds

--- a/cryptlib.cpp
+++ b/cryptlib.cpp
@@ -318,15 +318,37 @@ void RandomNumberGenerator::GenerateBlock(byte *output, size_t size)
 
 void RandomNumberGenerator::DiscardBytes(size_t n)
 {
-	GenerateIntoBufferedTransformation(TheBitBucket(), DEFAULT_CHANNEL, n);
+	//try
+	//{
+	//	IncorporateEntropy((byte*)&n, sizeof(n));
+	//}
+	//catch(...)
+	//{
+		GenerateIntoBufferedTransformation(TheBitBucket(), DEFAULT_CHANNEL, n);
+	//}
+}
+
+void RandomNumberGenerator::discard(unsigned long long z)
+{
+	//try
+	//{
+	//	IncorporateEntropy((byte*)&z, sizeof(z));
+	//}
+	//catch(...)
+	//{
+		GenerateIntoBufferedTransformation(TheBitBucket(), DEFAULT_CHANNEL, z * sizeof(result_type));
+	//}
 }
 
 void RandomNumberGenerator::GenerateIntoBufferedTransformation(BufferedTransformation &target, const std::string &channel, lword length)
 {
 	FixedSizeSecBlock<byte, 256> buffer;
-	while (length)
+
+	size_t len;
+
+	while(length > 0)
 	{
-		size_t len = UnsignedMin(buffer.size(), length);
+		len = UnsignedMin(buffer.size(), length);
 		GenerateBlock(buffer, len);
 		(void)target.ChannelPut(channel, buffer, len);
 		length -= len;

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -1331,6 +1331,26 @@ protected:
 class CRYPTOPP_DLL CRYPTOPP_NO_VTABLE RandomNumberGenerator : public Algorithm
 {
 public:
+
+	/// \brief The return type for operator()
+	/// \details Alias added to comply with the standard library RNG interface.
+	using result_type = size_t;
+
+	/// \brief Constructs a RandomNumberGenerator
+	RandomNumberGenerator() = default;
+
+	/// \brief Constructs a RandomNumberGenerator, and incorporates an additional seed into the internal state
+	/// \param seedVal a seed value to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	explicit RandomNumberGenerator(result_type seedVal) {seed(seedVal);}
+
+	/// \brief Constructs a RandomNumberGenerator, and incorporates an additional seed into the internal state
+	/// \param q a seed sequence to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	template <class Sseq> explicit RandomNumberGenerator(Sseq& q) {seed(q);}
+
 	virtual ~RandomNumberGenerator() {}
 
 	/// \brief Update RNG state with additional unpredictable values
@@ -1400,6 +1420,13 @@ public:
 	/// \param n the number of bytes to generate and discard
 	virtual void DiscardBytes(size_t n);
 
+	/// \brief Advances the internal state by z notches
+	/// \param z the number of equivalent advances
+	/// \details Advances the internal state by z notches, as if operator() was called z times,
+	///   but without generating any numbers in the process.
+	/// \details Member function added to comply with the standard library RNG interface.
+	void discard(unsigned long long z);
+
 	/// \brief Randomly shuffle the specified array
 	/// \param begin an iterator to the first element in the array
 	/// \param end an iterator beyond the last element in the array
@@ -1409,6 +1436,58 @@ public:
 		// TODO: What happens if there are more than 2^32 elements?
 		for (; begin != end; ++begin)
 			std::iter_swap(begin, begin + GenerateWord32(0, static_cast<word32>(end-begin-1)));
+	}
+
+	/// \brief The minimum return value for operator()
+	/// \details Static member function added to comply with the standard library RNG interface.
+	static constexpr result_type min() {return std::numeric_limits<result_type>::lowest();}
+
+	/// \brief The maximum return value for operator()
+	/// \details Static member function added to comply with the standard library RNG interface.
+	static constexpr result_type max() {return std::numeric_limits<result_type>::max();}
+
+	/// \brief Incorporates an additional seed into the internal state
+	/// \param val a seed value to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Member function added to comply with the standard library RNG interface.
+	void seed(result_type val = 1)
+	{
+		try
+		{
+			IncorporateEntropy((byte*)&val, sizeof(val));
+		}
+		catch(...)
+		{
+			// TODO: seed some other way, if IncorporateEntropy is not implemented.
+		}
+	}
+
+	/// \brief Incorporates an additional seed into the internal state
+	/// \param q a seed sequence to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Member function added to comply with the standard library RNG interface.
+	template <class Sseq> void seed(Sseq& q)
+	{
+		FixedSizeAlignedSecBlock<result_type, 4> seqResult;
+		Sseq.generate(seqResult.data(), result.data() + 4);
+
+		try
+		{
+			IncorporateEntropy((byte*)seqResult.data(), 4 * sizeof(result_type));
+		}
+		catch(...)
+		{
+			// TODO: seed some other way, if IncorporateEntropy is not implemented.
+		}
+	}
+
+	/// \brief Returns a new random number
+	/// \details Operator overloaded to comply with the standard library RNG interface.
+	result_type operator()()
+	{
+		result_type r;
+		GenerateBlock((byte*)&r,sizeof(r));
+		return r;
 	}
 };
 

--- a/osrng.cpp
+++ b/osrng.cpp
@@ -254,6 +254,13 @@ void OS_GenerateRandomBlock(bool blocking, byte *output, size_t size)
 	}
 }
 
+void AutoSeededRandomPool::Reseed(bool blocking)
+{
+	FixedSizeAlignedSecBlock<byte, DEFAULT_SEEDSIZE> seed;
+	OS_GenerateRandomBlock(blocking, seed, DEFAULT_SEEDSIZE);
+	IncorporateEntropy(seed, DEFAULT_SEEDSIZE);
+}
+
 void AutoSeededRandomPool::Reseed(bool blocking, unsigned int seedSize)
 {
 	SecByteBlock seed(seedSize);

--- a/osrng.h
+++ b/osrng.h
@@ -155,22 +155,53 @@ CRYPTOPP_DLL void CRYPTOPP_API OS_GenerateRandomBlock(bool blocking, byte *outpu
 class CRYPTOPP_DLL AutoSeededRandomPool : public RandomPool
 {
 public:
+	CRYPTOPP_STATIC_CONSTEXPR unsigned int DEFAULT_SEEDSIZE = 48;
+
 	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() { return "AutoSeededRandomPool"; }
 
 	~AutoSeededRandomPool() {}
 
 	/// \brief Construct an AutoSeededRandomPool
 	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	/// \details Use blocking to choose seeding with BlockingRng or NonblockingRng.
+	///   The blocking parameter is ignored if only one of these is available.
+	explicit AutoSeededRandomPool(bool blocking = false)
+		{Reseed(blocking);}
+
+	/// \brief Construct an AutoSeededRandomPool
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
 	/// \param seedSize the size of the seed, in bytes
 	/// \details Use blocking to choose seeding with BlockingRng or NonblockingRng.
-	///   The parameter is ignored if only one of these is available.
-	explicit AutoSeededRandomPool(bool blocking = false, unsigned int seedSize = 32)
+	///   The blocking parameter is ignored if only one of these is available.
+	AutoSeededRandomPool(bool blocking, unsigned int seedSize)
 		{Reseed(blocking, seedSize);}
+
+	/// \brief Constructs an AutoSeededRandomPool object, and incorporates an additional seed into the internal state
+	/// \param seedVal a seed value to be incorporated into the internal state
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	explicit AutoSeededRandomPool(result_type seedVal, bool blocking = false)
+		: RandomPool(seedVal)
+		{Reseed(blocking);}
+
+	/// \brief Constructs an AutoSeededRandomPool object, and incorporates an additional seed into the internal state
+	/// \param q a seed sequence to be incorporated into the internal state
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	template <class Sseq> explicit AutoSeededRandomPool(Sseq& q, bool blocking = false)
+		: RandomPool(q)
+		{Reseed(blocking);}
+
+	/// \brief Reseed an AutoSeededRandomPool
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	void Reseed(bool blocking = false);
 
 	/// \brief Reseed an AutoSeededRandomPool
 	/// \param blocking controls seeding with BlockingRng or NonblockingRng
 	/// \param seedSize the size of the seed, in bytes
-	void Reseed(bool blocking = false, unsigned int seedSize = 32);
+	void Reseed(bool blocking, unsigned int seedSize);
 };
 
 /// \tparam BLOCK_CIPHER a block cipher
@@ -198,11 +229,31 @@ public:
 	explicit AutoSeededX917RNG(bool blocking = false, bool autoSeed = true)
 		{if (autoSeed) Reseed(blocking);}
 
+	/// \brief Constructs an AutoSeededRandomPool object, and incorporates an additional seed into the internal state
+	/// \param seedVal a seed value to be incorporated into the internal state
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	/// \param autoSeed controls auto seeding of the generator
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	explicit AutoSeededX917RNG(result_type seedVal, bool blocking = false, bool autoSeed = true)
+		: RandomNumberGenerator(seedVal)
+		{if (autoSeed) Reseed(blocking);}
+
+	/// \brief Constructs an AutoSeededRandomPool object, and incorporates an additional seed into the internal state
+	/// \param q a seed sequence to be incorporated into the internal state
+	/// \param blocking controls seeding with BlockingRng or NonblockingRng
+	/// \param autoSeed controls auto seeding of the generator
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	template <class Sseq> explicit AutoSeededX917RNG(Sseq& q, bool blocking = false, bool autoSeed = true)
+		: RandomNumberGenerator(q)
+		{if (autoSeed) Reseed(blocking);}
+
 	/// \brief Reseed an AutoSeededX917RNG
 	/// \param blocking controls seeding with BlockingRng or NonblockingRng
 	/// \param additionalEntropy additional entropy to add to the generator
 	/// \param length the size of the additional entropy, in bytes
-	/// \details Internally, the generator uses SHA256 to extract the entropy from
+	/// \details Internally, the generator uses SHA-384 to extract the entropy from
 	///   from the seed and then stretch the material for the block cipher's key
 	///   and initialization vector.
 	void Reseed(bool blocking = false, const byte *additionalEntropy = NULLPTR, size_t length = 0);
@@ -241,7 +292,7 @@ void AutoSeededX917RNG<BLOCK_CIPHER>::Reseed(bool blocking, const byte *input, s
 		OS_GenerateRandomBlock(blocking, seed, seed.size());
 		if (length > 0)
 		{
-			SHA256 hash;
+			SHA384 hash;
 			hash.Update(seed, seed.size());
 			hash.Update(input, length);
 			hash.TruncatedFinal(seed, UnsignedMin(hash.DigestSize(), seed.size()));

--- a/randpool.h
+++ b/randpool.h
@@ -5,7 +5,7 @@
 /// \brief Class file for Randomness Pool
 /// \details RandomPool can be used to generate cryptographic quality pseudorandom bytes
 ///   after seeding the pool with IncorporateEntropy(). Internally, the generator uses
-///   AES-256 to produce the stream. Entropy is stirred in using SHA-256.
+///   AES-256 to produce the stream. Entropy is stirred in using SHA-384.
 /// \details RandomPool used to follow the design of randpool in PGP 2.6.x. At version 5.5
 ///   RandomPool was redesigned to reduce the risk of reusing random numbers after state
 ///   rollback (which may occur when running in a virtual machine like VMware or a hosted
@@ -29,7 +29,7 @@ NAMESPACE_BEGIN(CryptoPP)
 /// \brief Randomness Pool based on AES-256
 /// \details RandomPool can be used to generate cryptographic quality pseudorandom bytes
 ///   after seeding the pool with IncorporateEntropy(). Internally, the generator uses
-///   AES-256 to produce the stream. Entropy is stirred in using SHA-256.
+///   AES-256 to produce the stream. Entropy is stirred in using SHA-384.
 /// \details RandomPool used to follow the design of randpool in PGP 2.6.x. At version 5.5
 ///   RandomPool was redesigned to reduce the risk of reusing random numbers after state
 ///   rollback, which may occur when running in a virtual machine like VMware or a hosted
@@ -44,14 +44,25 @@ public:
 	/// \brief Construct a RandomPool
 	RandomPool();
 
+	/// \brief Constructs a RandomPool, and incorporates an additional seed into the internal state
+	/// \param seedVal a seed value to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	explicit RandomPool(result_type seedVal);
+
+	/// \brief Constructs a RandomPool, and incorporates an additional seed into the internal state
+	/// \param q a seed sequence to be incorporated into the internal state
+	/// \details Seeding with the same value twice, will not produce the same random number sequence.
+	/// \details Constructor added to comply with the standard library RNG interface.
+	template <class Sseq> explicit RandomPool(Sseq& q);
+
 	bool CanIncorporateEntropy() const {return true;}
 	void IncorporateEntropy(const byte *input, size_t length);
 	void GenerateIntoBufferedTransformation(BufferedTransformation &target, const std::string &channel, lword size);
 
 private:
-	FixedSizeAlignedSecBlock<byte, 16, true> m_seed;
-	FixedSizeAlignedSecBlock<byte, 32> m_key;
-	member_ptr<BlockCipher> m_pCipher;
+	FixedSizeAlignedSecBlock<byte, 48> m_seed;
+	AES::Encryption m_cipher;
 	bool m_keySet;
 };
 


### PR DESCRIPTION
Covers issue #572 , as well as some other updates.
_(Recreated pull request with a single commit.)_

Built and tested under debug and release modes, x64 and x86 platforms - all tests passed.

**Changes:**

AutoSeededRandomPool -
- Increased default seedSize from 32 bytes to 48 bytes.
- Added static constexpr member DEFAULT_SEEDSIZE = 48 (384 bits for AES-256).
- Added one additional overload of both the constructor and the Reseed member function (eliminating unnecessary DMA).
- Added constructors to match the standard library RNG interface.

AutoSeededX917RNG -
- Upgraded Reseed member function from SHA-256 to SHA-384. This generator was already performing similar behavior - namely, seeding all 384 bits when AES-256 is specified as the block cipher. After the change, the generator should be able to seed the entire cipher with valid hash bits. Should not affect 3DES etc. since the hash is truncated as needed.
- Added constructors to match the standard library RNG interface.

RandomPool -
- Optimized block processing loop.
- Upgraded IncorporateEntropy member function from SHA-256 to SHA-384.
- Combined m_seed and m_key into a single member variable (m_seed) of type FixedSizeAlignedSecBlock<byte, 48> (makes IncorporateEntropy faster/simpler).
- Replaced member variable m_pCipher with a new member variable (m_cipher) of type AES::Encryption (elimating unnecessary DMA).
- Set member variable m_keySet = true after calling m_cipher.SetKey(...) - this looks like a minor oversight.
- Added constructors to match the standard library RNG interface.

RandomNumberGenerator -
- Added class members to match the standard library RNG interface (result_type, min, max, seed/constructors, operator(), discard).

General -
- Updated documentation.
- Updated .gitignore to avoid additional Visual Studio build files, logs, and local symbol databases.