### PR TITLE
Fixed gitignore for VS, fixed RandomPool keySet flag, eliminated DMA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,11 +78,13 @@ local.properties
 
 [Dd]ebug/
 [Rr]elease/
-x64/
-build/
+[Ww]in32/
+[Xx]64/
+[Bb]uild/
 [Bb]in/
 [Oo]bj/
 [Ll]ibs/
+.vs/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
@@ -106,6 +108,7 @@ build/
 *.tmp
 *.tmp_proj
 *.log
+# *.tlog
 *.vspscc
 *.vssscc
 .builds

--- a/randpool.cpp
+++ b/randpool.cpp
@@ -23,7 +23,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 
 RandomPool::RandomPool()
-	: m_pCipher(new AES::Encryption), m_keySet(false)
+	: m_keySet(false)
 {
 	::memset(m_key, 0, m_key.SizeInBytes());
 	::memset(m_seed, 0, m_seed.SizeInBytes());
@@ -43,7 +43,10 @@ void RandomPool::GenerateIntoBufferedTransformation(BufferedTransformation &targ
 	if (size > 0)
 	{
 		if (!m_keySet)
-			m_pCipher->SetKey(m_key, 32);
+		{
+			m_cipher.SetKey(m_key, 32);
+			m_keySet = true;
+		}
 
 		CRYPTOPP_COMPILE_ASSERT(sizeof(TimerWord) <= 16);
 		CRYPTOPP_COMPILE_ASSERT(sizeof(time_t) <= 8);
@@ -67,7 +70,7 @@ void RandomPool::GenerateIntoBufferedTransformation(BufferedTransformation &targ
 
 		do
 		{
-			m_pCipher->ProcessBlock(m_seed);
+			m_cipher.ProcessBlock(m_seed);
 			size_t len = UnsignedMin(16, size);
 			target.ChannelPut(channel, m_seed, len);
 			size -= len;

--- a/randpool.h
+++ b/randpool.h
@@ -51,7 +51,7 @@ public:
 private:
 	FixedSizeAlignedSecBlock<byte, 16, true> m_seed;
 	FixedSizeAlignedSecBlock<byte, 32> m_key;
-	member_ptr<BlockCipher> m_pCipher;
+	AES::Encryption m_cipher;
 	bool m_keySet;
 };
 


### PR DESCRIPTION
In addition to all the SHA-384 stuff, there were a couple minor bugfixes mixed in PR #580 
(@noloader Thanks for the review and feedback on that PR.)

Since SHA-384 turns out to be slower (due to SHA-256 having intrinsics), and since you don't want to disturb the RandomNumberGenerator interface: I have removed those changes, and stripped this PR down to just the (seemingly) more important fixes.

Built and tested (Windows) under debug and release modes, x86 and x64 platforms - all tests passed.

- `.gitignore` was not ignoring Visual Studio build logs in the `.vs/` folder, so I updated `.gitignore` to cover these files (as a general rule, nothing in the `.vs/` folder should ever get synced to git)
- The `RandomPool::m_keySet` flag was never set to `true` after the key had been set. This appears to be a simple oversight when implementing the design logic, which I corrected.
- The `RandomPool::m_pCipher` pointer (smart pointer) appears to include unnecessary DMA every time a RandomPool object is constructed. This pointer is never reset to a new dynamic object (or dynamic array of objects), nor is it ever used by any other object. Since DMA is arguably one of the slowest operations provided by the standard C++ arsenal, it's best to convert the cipher into a regular non-dynamic data-member (especially since the cipher is a relatively small object to begin with).