### PR TITLE
Unbreak build on FreeBSD in C++17 mode

### DIFF
--- a/config.h
+++ b/config.h
@@ -1026,7 +1026,7 @@ NAMESPACE_END
 #endif // alignof
 
 // lambdas: MS at VS2012 (17.00); GCC at 4.9; Clang at 3.3; Intel 12.0; SunCC 5.14.
-#if (CRYPTOPP_MSC_VERSION >= 1700) || __has_feature(cxx_lambda) || \
+#if (CRYPTOPP_MSC_VERSION >= 1700) || __has_feature(cxx_lambdas) || \
 	(__INTEL_COMPILER >= 1200) || (CRYPTOPP_GCC_VERSION >= 40900) || (__SUNPRO_CC >= 0x5140)
 #  define CRYPTOPP_CXX11_LAMBDA 1
 #endif // lambdas


### PR DESCRIPTION
Found via citra-emu/citra#3435

```c++
$ c++ -v
FreeBSD clang version 6.0.0 (branches/release_60 324090) (based on LLVM 6.0.0)
Target: x86_64-unknown-freebsd12.0
Thread model: posix
InstalledDir: /usr/bin

$ CXXFLAGS=-std=gnu++17 gmake
c++ -std=gnu++17 -fPIC -pthread -pipe -c cryptlib.cpp
In file included from cryptlib.cpp:19:
./misc.h:2542:43: error: no member named 'bind2nd' in namespace 'std'
    return std::find_if(first, last, std::bind2nd(std::not_equal_to<T>(), value));
                                     ~~~~~^
1 error generated.
```
