### PR TITLE
Freeze ABI compatibility with LIB_MAJOR

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -688,8 +688,8 @@ endif
 ifeq ($(HAS_SOLIB_VERSION),1)
 # Full version suffix for shared library
 SOLIB_VERSION_SUFFIX=.$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)
-# Different patchlevels are compatible, minor versions are not
-SOLIB_COMPAT_SUFFIX=.$(LIB_MAJOR).$(LIB_MINOR)
+# Different patchlevels and minors are compatible since 6.1
+SOLIB_COMPAT_SUFFIX=.$(LIB_MAJOR)
 SOLIB_FLAGS=-Wl,-soname,libcryptopp.so$(SOLIB_COMPAT_SUFFIX)
 endif # HAS_SOLIB_VERSION
 

--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -332,8 +332,8 @@ endif
 ifeq ($(HAS_SOLIB_VERSION),1)
 # Full version suffix for shared library
 SOLIB_VERSION_SUFFIX=.$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)
-# Different patchlevels are compatible, minor versions are not
-SOLIB_COMPAT_SUFFIX=.$(LIB_MAJOR).$(LIB_MINOR)
+# Different patchlevels and minors are compatible since 6.1
+SOLIB_COMPAT_SUFFIX=.$(LIB_MAJOR)
 SOLIB_FLAGS=-Wl,-soname,libcryptopp.so$(SOLIB_COMPAT_SUFFIX)
 endif # HAS_SOLIB_VERSION
 


### PR DESCRIPTION
This is a convention that binary compatibity uses one number.
Using that, it's possible to have bugfixes releases (patchlevel
incremented) and enhancement release (minor incremented with no
public interface removed).

Here is more information about convention
https://autotools.io/libtool/version.html
(libtool isn't relevant to this project, but the explanation hold)

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>