### PR TITLE
Define AT_HWCAP/AT_HWCAP2 if getauxval unavailable

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -30,6 +30,12 @@
 #if CRYPTOPP_GETAUXV_AVAILABLE
 # include <sys/auxv.h>
 #else
+#ifndef AT_HWCAP
+#define AT_HWCAP 16
+#endif
+#ifndef AT_HWCAP2
+#define AT_HWCAP2 26
+#endif
 unsigned long int getauxval(unsigned long int) { return 0; }
 #endif
 


### PR DESCRIPTION
If CRYPTOPP_GETAUXV_AVAILABLE is undefined, getauxval function is
defined to return 0 however AT_HWCAP and AT_HWCAP2 are not defined so
compilation on toolchain without getauxval and these variables such as
uclibc-ng will fail.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>