### PR TITLE
Remove extra ;s from misc.h

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -109,13 +109,13 @@ T NumericLimitsMin()
 {
 	CRYPTOPP_ASSERT(std::numeric_limits<T>::is_specialized);
 	return (std::numeric_limits<T>::min)();
-};
+}
 template<class T>
 T NumericLimitsMax()
 {
 	CRYPTOPP_ASSERT(std::numeric_limits<T>::is_specialized);
 	return (std::numeric_limits<T>::max)();
-};
+}
 #if defined(CRYPTOPP_WORD128_AVAILABLE)
 template<>
 CryptoPP::word128 NumericLimitsMin()


### PR DESCRIPTION
When compiling I get:

    submodules/cryptopp/misc.h:112:2: varoitus: ylimääräinen ”;” [-Wpedantic]
    submodules/cryptopp/misc.h:118:2: varoitus: ylimääräinen ”;” [-Wpedantic]

with gcc 6.4.1 so remove extra ;s to suppress the warnings.