### PR TITLE
Remove extra ;s from oids.h

### DIFF
--- a/oids.h
+++ b/oids.h
@@ -52,7 +52,7 @@ DEFINE_OID(1, iso)
 			DEFINE_OID(iso_us()+113549, rsadsi)
 				DEFINE_OID(rsadsi()+1, pkcs)
 					DEFINE_OID(pkcs()+1, pkcs_1)
-						DEFINE_OID(pkcs_1()+1, rsaEncryption);
+						DEFINE_OID(pkcs_1()+1, rsaEncryption)
 				DEFINE_OID(rsadsi()+2, rsadsi_digestAlgorithm)
 					DEFINE_OID(rsadsi_digestAlgorithm()+2, id_md2)
 					DEFINE_OID(rsadsi_digestAlgorithm()+5, id_md5)
@@ -68,11 +68,11 @@ DEFINE_OID(1, iso)
 								DEFINE_OID(ellipticCurve()+2,curve448)
 								DEFINE_OID(ellipticCurve()+3,curve25519ph)
 								DEFINE_OID(ellipticCurve()+4,curve448ph)
-		DEFINE_OID(identified_organization()+14, oiw);
-			DEFINE_OID(oiw()+3, oiw_secsig);
-				DEFINE_OID(oiw_secsig()+2, oiw_secsig_algorithms);
-					DEFINE_OID(oiw_secsig_algorithms()+26, id_sha1);
-		DEFINE_OID(identified_organization()+36, teletrust);
+		DEFINE_OID(identified_organization()+14, oiw)
+			DEFINE_OID(oiw()+3, oiw_secsig)
+				DEFINE_OID(oiw_secsig()+2, oiw_secsig_algorithms)
+					DEFINE_OID(oiw_secsig_algorithms()+26, id_sha1)
+		DEFINE_OID(identified_organization()+36, teletrust)
 			DEFINE_OID(teletrust()+3, teletrust_algorithm)
 				DEFINE_OID(teletrust_algorithm()+2+1, id_ripemd160)
 				DEFINE_OID(teletrust_algorithm()+3+2+8+1, teletrust_ellipticCurve)
@@ -83,42 +83,42 @@ DEFINE_OID(1, iso)
 					DEFINE_OID(teletrust_ellipticCurve()+1+9, brainpoolP320r1)
 					DEFINE_OID(teletrust_ellipticCurve()+1+11, brainpoolP384r1)
 					DEFINE_OID(teletrust_ellipticCurve()+1+13, brainpoolP512r1)
-		DEFINE_OID(identified_organization()+132, certicom);
-			DEFINE_OID(certicom()+0, certicom_ellipticCurve);
+		DEFINE_OID(identified_organization()+132, certicom)
+			DEFINE_OID(certicom()+0, certicom_ellipticCurve)
 				// these are sorted by curve type and then by OID
 				// first curves based on GF(p)
-				DEFINE_OID(certicom_ellipticCurve()+6, secp112r1);
-				DEFINE_OID(certicom_ellipticCurve()+7, secp112r2);
-				DEFINE_OID(certicom_ellipticCurve()+8, secp160r1);
-				DEFINE_OID(certicom_ellipticCurve()+9, secp160k1);
-				DEFINE_OID(certicom_ellipticCurve()+10, secp256k1);
-				DEFINE_OID(certicom_ellipticCurve()+28, secp128r1);
-				DEFINE_OID(certicom_ellipticCurve()+29, secp128r2);
-				DEFINE_OID(certicom_ellipticCurve()+30, secp160r2);
-				DEFINE_OID(certicom_ellipticCurve()+31, secp192k1);
-				DEFINE_OID(certicom_ellipticCurve()+32, secp224k1);
-				DEFINE_OID(certicom_ellipticCurve()+33, secp224r1);
-				DEFINE_OID(certicom_ellipticCurve()+34, secp384r1);
-				DEFINE_OID(certicom_ellipticCurve()+35, secp521r1);
+				DEFINE_OID(certicom_ellipticCurve()+6, secp112r1)
+				DEFINE_OID(certicom_ellipticCurve()+7, secp112r2)
+				DEFINE_OID(certicom_ellipticCurve()+8, secp160r1)
+				DEFINE_OID(certicom_ellipticCurve()+9, secp160k1)
+				DEFINE_OID(certicom_ellipticCurve()+10, secp256k1)
+				DEFINE_OID(certicom_ellipticCurve()+28, secp128r1)
+				DEFINE_OID(certicom_ellipticCurve()+29, secp128r2)
+				DEFINE_OID(certicom_ellipticCurve()+30, secp160r2)
+				DEFINE_OID(certicom_ellipticCurve()+31, secp192k1)
+				DEFINE_OID(certicom_ellipticCurve()+32, secp224k1)
+				DEFINE_OID(certicom_ellipticCurve()+33, secp224r1)
+				DEFINE_OID(certicom_ellipticCurve()+34, secp384r1)
+				DEFINE_OID(certicom_ellipticCurve()+35, secp521r1)
 				// then curves based on GF(2^n)
-				DEFINE_OID(certicom_ellipticCurve()+1, sect163k1);
-				DEFINE_OID(certicom_ellipticCurve()+2, sect163r1);
-				DEFINE_OID(certicom_ellipticCurve()+3, sect239k1);
-				DEFINE_OID(certicom_ellipticCurve()+4, sect113r1);
-				DEFINE_OID(certicom_ellipticCurve()+5, sect113r2);
-				DEFINE_OID(certicom_ellipticCurve()+15, sect163r2);
-				DEFINE_OID(certicom_ellipticCurve()+16, sect283k1);
-				DEFINE_OID(certicom_ellipticCurve()+17, sect283r1);
-				DEFINE_OID(certicom_ellipticCurve()+22, sect131r1);
-				DEFINE_OID(certicom_ellipticCurve()+23, sect131r2);
-				DEFINE_OID(certicom_ellipticCurve()+24, sect193r1);
-				DEFINE_OID(certicom_ellipticCurve()+25, sect193r2);
-				DEFINE_OID(certicom_ellipticCurve()+26, sect233k1);
-				DEFINE_OID(certicom_ellipticCurve()+27, sect233r1);
-				DEFINE_OID(certicom_ellipticCurve()+36, sect409k1);
-				DEFINE_OID(certicom_ellipticCurve()+37, sect409r1);
-				DEFINE_OID(certicom_ellipticCurve()+38, sect571k1);
-				DEFINE_OID(certicom_ellipticCurve()+39, sect571r1);
+				DEFINE_OID(certicom_ellipticCurve()+1, sect163k1)
+				DEFINE_OID(certicom_ellipticCurve()+2, sect163r1)
+				DEFINE_OID(certicom_ellipticCurve()+3, sect239k1)
+				DEFINE_OID(certicom_ellipticCurve()+4, sect113r1)
+				DEFINE_OID(certicom_ellipticCurve()+5, sect113r2)
+				DEFINE_OID(certicom_ellipticCurve()+15, sect163r2)
+				DEFINE_OID(certicom_ellipticCurve()+16, sect283k1)
+				DEFINE_OID(certicom_ellipticCurve()+17, sect283r1)
+				DEFINE_OID(certicom_ellipticCurve()+22, sect131r1)
+				DEFINE_OID(certicom_ellipticCurve()+23, sect131r2)
+				DEFINE_OID(certicom_ellipticCurve()+24, sect193r1)
+				DEFINE_OID(certicom_ellipticCurve()+25, sect193r2)
+				DEFINE_OID(certicom_ellipticCurve()+26, sect233k1)
+				DEFINE_OID(certicom_ellipticCurve()+27, sect233r1)
+				DEFINE_OID(certicom_ellipticCurve()+36, sect409k1)
+				DEFINE_OID(certicom_ellipticCurve()+37, sect409r1)
+				DEFINE_OID(certicom_ellipticCurve()+38, sect571k1)
+				DEFINE_OID(certicom_ellipticCurve()+39, sect571r1)
 DEFINE_OID(2, joint_iso_ccitt)
 	DEFINE_OID(joint_iso_ccitt()+16, country)
 		DEFINE_OID(country()+840, joint_iso_ccitt_us)


### PR DESCRIPTION
When compiling with gcc 6.4.1:
```
submodules/cryptopp/oids.h:55:44: varoitus: ylimääräinen ”;” [-Wpedantic]
       DEFINE_OID(pkcs_1()+1, rsaEncryption);
                                            ^
submodules/cryptopp/oids.h:71:48: varoitus: ylimääräinen ”;” [-Wpedantic]
   DEFINE_OID(identified_organization()+14, oiw);
                                                ^
submodules/cryptopp/oids.h:72:35: varoitus: ylimääräinen ”;” [-Wpedantic]
    DEFINE_OID(oiw()+3, oiw_secsig);
                                   ^
submodules/cryptopp/oids.h:73:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(oiw_secsig()+2, oiw_secsig_algorithms);
                                                      ^
submodules/cryptopp/oids.h:74:53: varoitus: ylimääräinen ”;” [-Wpedantic]
      DEFINE_OID(oiw_secsig_algorithms()+26, id_sha1);
                                                     ^
submodules/cryptopp/oids.h:75:54: varoitus: ylimääräinen ”;” [-Wpedantic]
   DEFINE_OID(identified_organization()+36, teletrust);
                                                      ^
submodules/cryptopp/oids.h:86:54: varoitus: ylimääräinen ”;” [-Wpedantic]
   DEFINE_OID(identified_organization()+132, certicom);
                                                      ^
submodules/cryptopp/oids.h:87:52: varoitus: ylimääräinen ”;” [-Wpedantic]
    DEFINE_OID(certicom()+0, certicom_ellipticCurve);
                                                    ^
submodules/cryptopp/oids.h:90:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+6, secp112r1);
                                                      ^
submodules/cryptopp/oids.h:91:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+7, secp112r2);
                                                      ^
submodules/cryptopp/oids.h:92:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+8, secp160r1);
                                                      ^
submodules/cryptopp/oids.h:93:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+9, secp160k1);
                                                      ^
submodules/cryptopp/oids.h:94:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+10, secp256k1);
                                                       ^
submodules/cryptopp/oids.h:95:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+28, secp128r1);
                                                       ^
submodules/cryptopp/oids.h:96:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+29, secp128r2);
                                                       ^
submodules/cryptopp/oids.h:97:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+30, secp160r2);
                                                       ^
submodules/cryptopp/oids.h:98:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+31, secp192k1);
                                                       ^
submodules/cryptopp/oids.h:99:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+32, secp224k1);
                                                       ^
submodules/cryptopp/oids.h:100:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+33, secp224r1);
                                                       ^
submodules/cryptopp/oids.h:101:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+34, secp384r1);
                                                       ^
submodules/cryptopp/oids.h:102:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+35, secp521r1);
                                                       ^
submodules/cryptopp/oids.h:104:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+1, sect163k1);
                                                      ^
submodules/cryptopp/oids.h:105:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+2, sect163r1);
                                                      ^
submodules/cryptopp/oids.h:106:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+3, sect239k1);
                                                      ^
submodules/cryptopp/oids.h:107:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+4, sect113r1);
                                                      ^
submodules/cryptopp/oids.h:108:54: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+5, sect113r2);
                                                      ^
submodules/cryptopp/oids.h:109:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+15, sect163r2);
                                                       ^
submodules/cryptopp/oids.h:110:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+16, sect283k1);
                                                       ^
submodules/cryptopp/oids.h:111:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+17, sect283r1);
                                                       ^
submodules/cryptopp/oids.h:112:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+22, sect131r1);
                                                       ^
submodules/cryptopp/oids.h:113:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+23, sect131r2);
                                                       ^
submodules/cryptopp/oids.h:114:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+24, sect193r1);
                                                       ^
submodules/cryptopp/oids.h:115:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+25, sect193r2);
                                                       ^
submodules/cryptopp/oids.h:116:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+26, sect233k1);
                                                       ^
submodules/cryptopp/oids.h:117:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+27, sect233r1);
                                                       ^
submodules/cryptopp/oids.h:118:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+36, sect409k1);
                                                       ^
submodules/cryptopp/oids.h:119:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+37, sect409r1);
                                                       ^
submodules/cryptopp/oids.h:120:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+38, sect571k1);
                                                       ^
submodules/cryptopp/oids.h:121:55: varoitus: ylimääräinen ”;” [-Wpedantic]
     DEFINE_OID(certicom_ellipticCurve()+39, sect571r1);
                                                       ^
```