### PR TITLE
Remove extra ; from cpu.cpp

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -59,7 +59,7 @@ NAMESPACE_BEGIN(CryptoPP)
 #ifndef CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 extern "C" {
     typedef void (*SigHandler)(int);
-};
+}
 
 extern "C"
 {


### PR DESCRIPTION
Compiling with -W -Wall -Wextra -pedantic gives:
```
cpu.cpp:62:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```