### PR TITLE
Remove extra ; from crc-simd.cpp

### DIFF
--- a/crc-simd.cpp
+++ b/crc-simd.cpp
@@ -46,7 +46,7 @@ extern "C" {
     {
         longjmp(s_jmpSIGILL, 1);
     }
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 #if (CRYPTOPP_BOOL_ARM32 || CRYPTOPP_BOOL_ARM64)


### PR DESCRIPTION
compiling with gcc -pedantic gives a warning:
```
crc-simd.cpp:49:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```