### PR TITLE
Remove extra ; from gcm-simd.cpp

### DIFF
--- a/gcm-simd.cpp
+++ b/gcm-simd.cpp
@@ -203,7 +203,7 @@ extern "C" {
     {
         longjmp(s_jmpSIGILL, 1);
     }
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 #if (CRYPTOPP_BOOL_ARM32 || CRYPTOPP_BOOL_ARM64)


### PR DESCRIPTION
Removes gcc -pedantic warning:
```
gcm-simd.cpp:206:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```