### PR TITLE
Remove extra ; from neon-simd.cpp

### DIFF
--- a/neon-simd.cpp
+++ b/neon-simd.cpp
@@ -41,7 +41,7 @@ extern "C" {
 	{
 		longjmp(s_jmpSIGILL, 1);
 	}
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 bool CPU_ProbeNEON()


### PR DESCRIPTION
Fixes gcc -pedanticc warning:
```
neon-simd.cpp:44:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```