### PR TITLE
Remove extra ; from ppc-simd.cpp

### DIFF
--- a/ppc-simd.cpp
+++ b/ppc-simd.cpp
@@ -48,7 +48,7 @@ extern "C" {
     {
         longjmp(s_jmpSIGILL, 1);
     }
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 #if (CRYPTOPP_BOOL_PPC32 || CRYPTOPP_BOOL_PPC64)


### PR DESCRIPTION
Fixes warning from gcc -pedantic:
```
ppc-simd.cpp:51:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```