### PR TITLE
Remove extra ; from rijndael-simd.cpp

### DIFF
--- a/rijndael-simd.cpp
+++ b/rijndael-simd.cpp
@@ -77,7 +77,7 @@ extern "C" {
     {
         longjmp(s_jmpSIGILL, 1);
     }
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 #if (CRYPTOPP_BOOL_ARM32 || CRYPTOPP_BOOL_ARM64)


### PR DESCRIPTION
Fixes warning from gcc -pedantic:
```
rijndael-simd.cpp:80:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```