### PR TITLE
Remove extra ; from sha-simd.cpp

### DIFF
--- a/sha-simd.cpp
+++ b/sha-simd.cpp
@@ -58,7 +58,7 @@ extern "C" {
     {
         longjmp(s_jmpSIGILL, 1);
     }
-};
+}
 #endif  // Not CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 
 #if (CRYPTOPP_BOOL_ARM32 || CRYPTOPP_BOOL_ARM64)


### PR DESCRIPTION
Fixes warning from gcc -pedantic:
```
sha-simd.cpp:61:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```