### PR TITLE
Remove extra ; from sse-simd.cpp

### DIFF
--- a/sse-simd.cpp
+++ b/sse-simd.cpp
@@ -32,7 +32,7 @@ NAMESPACE_BEGIN(CryptoPP)
 #ifndef CRYPTOPP_MS_STYLE_INLINE_ASSEMBLY
 extern "C" {
     typedef void (*SigHandler)(int);
-};
+}
 
 extern "C"
 {


### PR DESCRIPTION
Fixes warning from gcc -pedantic:
```
sse-simd.cpp:35:2: virhe: ylimääräinen ”;” [-Werror=pedantic]
 };
  ^
```