### PR TITLE
Add OpenMP support to Scrypt (GH #613)

### DIFF
--- a/TestScripts/cryptest-ios.sh
+++ b/TestScripts/cryptest-ios.sh
@@ -25,7 +25,7 @@ do
 	echo "Testing for iOS support of $platform"
 
 	# Test if we can set the environment for the platform
-	./setenv-ios.sh "$platform" "$runtime"
+	./setenv-ios.sh "$platform"
 
 	if [ "$?" -eq "0" ]; then
 		echo

--- a/scrypt.h
+++ b/scrypt.h
@@ -1,5 +1,5 @@
 // scrypt.h - written and placed in public domain by Jeffrey Walton.
-//            Based on reference source code by Colin Percival and Simon Josefsson.
+//            Based on reference source code by Colin Percival.
 
 /// \file scrypt.h
 /// \brief Classes for Scrypt from RFC 7914


### PR DESCRIPTION
Scrypt performance jumps as expected. For example, on a machine with 4 logical cores:

    $ time OMP_NUM_THREADS=1 ./test.exe
    Threads: 1
    Key: DCF073537D25A10C9733...

    real    0m17.959s
    user    0m16.165s
    sys     0m1.759s

    $ time OMP_NUM_THREADS=4 ./test.exe
    Threads: 4
    Key: B37A0127DBE178ED604F...

    real    0m4.488s
    user    0m15.391s
    sys     0m1.981s