### PR TITLE
Fix ios build for cases where Xcode is installed in a path with spaces

### DIFF
--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -88,7 +88,7 @@ ifeq ($(IS_IOS),1)
   CXX = clang++
 
   CXXFLAGS += $(IOS_FLAGS) -arch $(IOS_ARCH)
-  CXXFLAGS += -isysroot $(IOS_SYSROOT) -stdlib=libc++
+  CXXFLAGS += -isysroot "$(IOS_SYSROOT)" -stdlib=libc++
 
   AR = libtool
   ARFLAGS = -static -o


### PR DESCRIPTION
IOS build fails if Xcode is installed in a path with spaces. Fix quoting.
