### PR TITLE
Add CRYPTOPP_ASSERT to iterhash so it matches Keccak and SHA3

### DIFF
--- a/iterhash.cpp
+++ b/iterhash.cpp
@@ -12,6 +12,7 @@ NAMESPACE_BEGIN(CryptoPP)
 
 template <class T, class BASE> void IteratedHashBase<T, BASE>::Update(const byte *input, size_t len)
 {
+	CRYPTOPP_ASSERT((input && len) || !(input || len));
 	HashWordType oldCountLo = m_countLo, oldCountHi = m_countHi;
 	if ((m_countLo = oldCountLo + HashWordType(len)) < oldCountLo)
 		m_countHi++;             // carry from low to high


### PR DESCRIPTION
As described in https://github.com/weidai11/cryptopp/issues/652 for consistency we should add assert in all hash transformations.
Expectation is to have a good pointer and a non-0 length or a null pointer and 0-length.