### PR TITLE
Fix clang warnings in headers

### DIFF
--- a/algparam.h
+++ b/algparam.h
@@ -28,7 +28,7 @@ public:
 	ConstByteArrayParameter(const char *data = NULLPTR, bool deepCopy = false)
 		: m_deepCopy(false), m_data(NULLPTR), m_size(0)
 	{
-		Assign((const byte *)data, data ? strlen(data) : 0, deepCopy);
+		Assign(reinterpret_cast<const byte *>(data), data ? strlen(data) : 0, deepCopy);
 	}
 
 	/// \brief Construct a ConstByteArrayParameter
@@ -53,7 +53,7 @@ public:
 		: m_deepCopy(false), m_data(NULLPTR), m_size(0)
 	{
 		CRYPTOPP_COMPILE_ASSERT(sizeof(typename T::value_type) == 1);
-		Assign((const byte *)string.data(), string.size(), deepCopy);
+		Assign(reinterpret_cast<const byte *>(string.data()), string.size(), deepCopy);
 	}
 
 	/// \brief Assign contents from a memory buffer

--- a/crc.h
+++ b/crc.h
@@ -34,7 +34,7 @@ public:
     std::string AlgorithmName() const {return StaticAlgorithmName();}
 
 	void UpdateByte(byte b) {m_crc = m_tab[CRC32_INDEX(m_crc) ^ b] ^ CRC32_SHIFTED(m_crc);}
-	byte GetCrcByte(size_t i) const {return ((byte *)&(m_crc))[i];}
+	byte GetCrcByte(size_t i) const {return reinterpret_cast<const byte *>(&m_crc)[i];}
 
 protected:
 	void Reset() {m_crc = CRC32_NEGL;}
@@ -59,7 +59,7 @@ public:
     std::string AlgorithmName() const {return StaticAlgorithmName();}
 
 	void UpdateByte(byte b) {m_crc = m_tab[CRC32_INDEX(m_crc) ^ b] ^ CRC32_SHIFTED(m_crc);}
-	byte GetCrcByte(size_t i) const {return ((byte *)&(m_crc))[i];}
+	byte GetCrcByte(size_t i) const {return reinterpret_cast<const byte *>(&m_crc)[i];}
 
 protected:
 	void Reset() {m_crc = CRC32_NEGL;}

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -131,7 +131,7 @@ const unsigned long INFINITE_TIME = ULONG_MAX;
 template <typename ENUM_TYPE, int VALUE>
 struct EnumToType
 {
-	static ENUM_TYPE ToEnum() {return (ENUM_TYPE)VALUE;}
+	static ENUM_TYPE ToEnum() {return static_cast<ENUM_TYPE>(VALUE);}
 };
 
 /// \brief Provides the byte ordering

--- a/filters.h
+++ b/filters.h
@@ -865,12 +865,12 @@ public:
 	/// \brief Stop redirecting input
 	void StopRedirection() {m_target = NULLPTR;}
 
-	Behavior GetBehavior() {return (Behavior) m_behavior;}
+	Behavior GetBehavior() {return static_cast<Behavior>(m_behavior);}
 	void SetBehavior(Behavior behavior) {m_behavior=behavior;}
 	bool GetPassSignals() const {return (m_behavior & PASS_SIGNALS) != 0;}
-	void SetPassSignals(bool pass) { if (pass) m_behavior |= PASS_SIGNALS; else m_behavior &= ~(word32) PASS_SIGNALS; }
+	void SetPassSignals(bool pass) { if (pass) m_behavior |= PASS_SIGNALS; else m_behavior &= ~static_cast<word32>(PASS_SIGNALS); }
 	bool GetPassWaitObjects() const {return (m_behavior & PASS_WAIT_OBJECTS) != 0;}
-	void SetPassWaitObjects(bool pass) { if (pass) m_behavior |= PASS_WAIT_OBJECTS; else m_behavior &= ~(word32) PASS_WAIT_OBJECTS; }
+	void SetPassWaitObjects(bool pass) { if (pass) m_behavior |= PASS_WAIT_OBJECTS; else m_behavior &= ~static_cast<word32>(PASS_WAIT_OBJECTS); }
 
 	bool CanModifyInput() const
 		{return m_target ? m_target->CanModifyInput() : false;}
@@ -1293,7 +1293,7 @@ public:
 	/// \details Internally, Pump() calls Pump2().
 	/// \note pumpMax is a \p lword, which is a 64-bit value that typically uses \p LWORD_MAX. The default
 	///   argument is a \p size_t that uses \p SIZE_MAX, and it can be 32-bits or 64-bits.
-	lword Pump(lword pumpMax=(size_t)SIZE_MAX)
+	lword Pump(lword pumpMax=SIZE_MAX)
 		{Pump2(pumpMax); return pumpMax;}
 
 	/// \brief Pump messages to attached transformation

--- a/iterhash.h
+++ b/iterhash.h
@@ -168,7 +168,7 @@ public:
 	/// \brief Provides the digest size of the hash
 	/// \return the digest size of the hash, in bytes
 	/// \details DigestSize() returns <tt>DIGESTSIZE</tt>.
-	unsigned int DigestSize() const {return DIGESTSIZE;};
+	unsigned int DigestSize() const {return DIGESTSIZE;}
 
 protected:
 	IteratedHashWithStaticTransform() {this->Init();}

--- a/modarith.h
+++ b/modarith.h
@@ -47,12 +47,12 @@ public:
 	/// \brief Construct a ModularArithmetic
 	/// \param modulus congruence class modulus
 	ModularArithmetic(const Integer &modulus = Integer::One())
-		: AbstractRing<Integer>(), m_modulus(modulus), m_result((word)0, modulus.reg.size()) {}
+		: AbstractRing<Integer>(), m_modulus(modulus), m_result(static_cast<word>(0), modulus.reg.size()) {}
 
 	/// \brief Copy construct a ModularArithmetic
 	/// \param ma other ModularArithmetic
 	ModularArithmetic(const ModularArithmetic &ma)
-		: AbstractRing<Integer>(), m_modulus(ma.m_modulus), m_result((word)0, ma.m_modulus.reg.size()) {}
+		: AbstractRing<Integer>(), m_modulus(ma.m_modulus), m_result(static_cast<word>(0), ma.m_modulus.reg.size()) {}
 
 	/// \brief Construct a ModularArithmetic
 	/// \param bt BER encoded ModularArithmetic

--- a/modes.h
+++ b/modes.h
@@ -80,7 +80,7 @@ public:
 
 protected:
 	CipherModeBase() : m_cipher(NULLPTR) {}
-	inline unsigned int BlockSize() const {CRYPTOPP_ASSERT(m_register.size() > 0); return (unsigned int)m_register.size();}
+	inline unsigned int BlockSize() const {CRYPTOPP_ASSERT(m_register.size() > 0); return static_cast<unsigned int>(m_register.size());}
 	virtual void SetFeedbackSize(unsigned int feedbackSize)
 	{
 		if (!(feedbackSize == 0 || feedbackSize == BlockSize()))
@@ -251,7 +251,7 @@ protected:
 	void UncheckedSetKey(const byte *key, unsigned int length, const NameValuePairs &params)
 	{
 		CBC_Encryption::UncheckedSetKey(key, length, params);
-		m_stolenIV = params.GetValueWithDefault(Name::StolenIV(), (byte *)NULLPTR);
+		m_stolenIV = params.GetValueWithDefault(Name::StolenIV(), static_cast<byte *>(NULLPTR));
 	}
 
 	byte *m_stolenIV;

--- a/secblock.h
+++ b/secblock.h
@@ -198,10 +198,10 @@ public:
 #if CRYPTOPP_BOOL_ALIGN16
 		// TODO: Does this need the test 'size*sizeof(T) >= 16'?
 		if (T_Align16 && size)
-			return (pointer)AlignedAllocate(size*sizeof(T));
+			return reinterpret_cast<pointer>(AlignedAllocate(size*sizeof(T)));
 #endif
 
-		return (pointer)UnalignedAllocate(size*sizeof(T));
+		return reinterpret_cast<pointer>(UnalignedAllocate(size*sizeof(T)));
 	}
 
 	/// \brief Deallocates a block of memory
@@ -217,7 +217,7 @@ public:
 		// This will fire if SetMark(0) was called in the SecBlock
 		//  Our self tests exercise it, disable it now.
 		// CRYPTOPP_ASSERT((ptr && size) || !(ptr || size));
-		SecureWipeArray((pointer)ptr, size);
+		SecureWipeArray(reinterpret_cast<pointer>(ptr), size);
 
 #if CRYPTOPP_BOOL_ALIGN16
 		if (T_Align16 && size)

--- a/strciphr.h
+++ b/strciphr.h
@@ -130,7 +130,7 @@ struct CRYPTOPP_DLL CRYPTOPP_NO_VTABLE AdditiveCipherAbstractPolicy
 	/// \param iterationCount the number of iterations to generate the key stream
 	/// \sa CanOperateKeystream(), OperateKeystream(), WriteKeystream()
 	virtual void WriteKeystream(byte *keystream, size_t iterationCount)
-		{OperateKeystream(KeystreamOperation(INPUT_NULL | (KeystreamOperationFlags)IsAlignedOn(keystream, GetAlignment())), keystream, NULLPTR, iterationCount);}
+		{OperateKeystream(KeystreamOperation(INPUT_NULL | static_cast<KeystreamOperationFlags>(IsAlignedOn(keystream, GetAlignment()))), keystream, NULLPTR, iterationCount);}
 
 	/// \brief Flag indicating
 	/// \returns true if the stream can be generated independent of the transformation input, false otherwise

--- a/trap.h
+++ b/trap.h
@@ -64,8 +64,8 @@
 #  define CRYPTOPP_ASSERT(exp) {                                  \
     if (!(exp)) {                                                 \
       std::ostringstream oss;                                     \
-      oss << "Assertion failed: " << (char*)(__FILE__) << "("     \
-          << (int)(__LINE__) << "): " << (char*)(__func__)        \
+      oss << "Assertion failed: " << __FILE__ << "("              \
+          << __LINE__ << "): " << __func__                        \
           << std::endl;                                           \
       std::cerr << oss.str();                                     \
       raise(SIGTRAP);                                             \
@@ -75,8 +75,8 @@
 #  define CRYPTOPP_ASSERT(exp) {                                  \
     if (!(exp)) {                                                 \
       std::ostringstream oss;                                     \
-      oss << "Assertion failed: " << (char*)(__FILE__) << "("     \
-          << (int)(__LINE__) << "): " << (char*)(__FUNCTION__)    \
+      oss << "Assertion failed: " << __FILE__ << "("              \
+          << __LINE__ << "): " << __FUNCTION__                    \
           << std::endl;                                           \
       std::cerr << oss.str();                                     \
       if (IsDebuggerPresent()) {DebugBreak();}                    \


### PR DESCRIPTION
clang warns about C-style casts with `-Wold-style-cast`. It also warns about implicitly casting away const with `-Wcast-qual`. Fix both by removing unnecessary casts and converting the remaining ones to C++ casts.

Also remove an extra semicolon triggering a `-Wextra-semi` warning.