### PR TITLE
NaCl: add default parameter for optional random generated sk

### DIFF
--- a/naclite.h
+++ b/naclite.h
@@ -367,11 +367,12 @@ int crypto_sign_open(byte *m,word64 *mlen,const byte *sm,word64 n,const byte *pk
 /// \brief Generate a keypair for signing
 /// \param pk public key byte buffer
 /// \param sk private key byte buffer
+/// \param rnd_sk generate random private key
 /// \details crypto_sign_keypair() creates an ed25519 keypair.
 /// \returns 0 on success, non-0 otherwise
 /// \sa <A HREF="https://nacl.cr.yp.to/sign.html">NaCl crypto_sign documentation</A>
 /// \since Crypto++ 6.0
-int crypto_sign_keypair(byte *pk, byte *sk);
+int crypto_sign_keypair(byte *pk, byte *sk, const bool rnd_sk = true);
 
 /// \brief Produce a keystream using XSalsa20
 /// \details crypto_stream() uses crypto_stream_xsalsa20

--- a/tweetnacl.cpp
+++ b/tweetnacl.cpp
@@ -736,13 +736,14 @@ static void scalarbase(gf p[4],const byte *s)
   scalarmult(p,q,s);
 }
 
-int crypto_sign_keypair(byte *pk, byte *sk)
+int crypto_sign_keypair(byte *pk, byte *sk, const bool rnd_sk)
 {
   byte d[64];
   gf p[4];
   int i;
 
-  randombytes(sk, 32);
+  if (rnd_sk)
+    randombytes(sk, 32);
   crypto_hash(d, sk, 32);
   d[0] &= 248;
   d[31] &= 127;


### PR DESCRIPTION
>This is useful for implementations who can't afford to clobber the
existing sk buffer or who are limited by their existing interface
(e.g., they *must* re-use the privkey).

This is needed for https://github.com/monero-project/kovri/pull/909.

@noloader I know, altering the interface is heresy. I welcome your feedback.