### PR TITLE
Fix build with Embarcadero C++Builder 10.2.3

### DIFF
--- a/adv-simd.h
+++ b/adv-simd.h
@@ -51,8 +51,13 @@
 # include <arm_acle.h>
 #endif
 
+#if (CRYPTOPP_SSE2_INTRIN_AVAILABLE)
+# include <emmintrin.h>
+# include <xmmintrin.h>
+#endif
+
 // SunCC needs CRYPTOPP_SSSE3_AVAILABLE, too
-#if (CRYPTOPP_SSE2_INTRIN_AVAILABLE || CRYPTOPP_SSSE3_AVAILABLE)
+#if (CRYPTOPP_SSSE3_AVAILABLE)
 # include <emmintrin.h>
 # include <pmmintrin.h>
 # include <xmmintrin.h>

--- a/cpu.cpp
+++ b/cpu.cpp
@@ -317,7 +317,7 @@ void DetectX86Features()
 	CRYPTOPP_CONSTANT(AVX_FLAG = (3 << 27))
 	if ((cpuid1[2] & AVX_FLAG) == AVX_FLAG)
 	{
-#if defined(__GNUC__) || defined(__SUNPRO_CC)
+#if defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__BORLANDC__)
 		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71659 and
 		// http://www.agner.org/optimize/vectorclass/read.php?i=65
 		word32 a=0, d=0;


### PR DESCRIPTION
Fix two compilation errors encountered with C++Builder (Starter Edition):

 - In `cpu.cpp`, 0ccdc197b introduced a dependency on `_xgetbv()` from `<immintrin.h>` that doesn't exist on C++Builder. **Enlist C++Builder for the workaround**, similar to SunCC in 692ed2a2b.

 - In `adv-simd.h`, `<pmmintrin.h>` is being #included under the `CRYPTOPP_SSE2_INTRIN_AVAILABLE` macro. This header, [which apparently provides SSE3 intrinsics](https://stackoverflow.com/a/11228864/1433768), is not shipped with C++Builder. (This section of code was recently downgraded from a SSSE3 to a SSE2 block in 09c8ae28, followed by moving away from `<immintrin.h>` in bc8da71a, followed by reintroducing the SSSE3 check in d1e646a5.) **Split the SSE2 and SSSE3 cases such that `<pmmintrin.h>` is not #included for SSE2.** This seems safe to do, because some `git grep` analysis shows that:
    - `adv-simd.h` is not #included by any other header, but only directly #included by some `.cpp` files.
    - Among those `.cpp` files, only `sm4-simd.cpp` has a `CRYPTOPP_SSE2_INTRIN_AVAILABLE` preprocessor block, and there it again includes the other two headers (`<emmintrin.h>` and `<xmmintrin.h>`).

NOTE: I was compiling via the IDE after [setting up a project file](https://github.com/tanzislam/cryptopals/wiki/Importing-into-Embarcadero-C%E2%94%BC%E2%94%BCBuilder-Starter-10.2#using-the-crypto-library). My compilation command was effectively:

```
bcc32c.exe -DCRYPTOPP_NO_CXX11 -DCRYPTOPP_DISABLE_SSSE3 -D__SSE2__ -D__SSE__ -D__MMX__ <filename>
```