### PR TITLE
Disable X32 inline assembly (GH #686)

### DIFF
--- a/gcm-simd.cpp
+++ b/gcm-simd.cpp
@@ -12,10 +12,7 @@
 #include "config.h"
 #include "misc.h"
 
-// Clang 3.3 integrated assembler crash on Linux. Other versions
-// produce incorrect results. Clang has never handled Intel ASM
-// very well. I wish LLVM would fix it.
-#if defined(CRYPTOPP_DISABLE_INTEL_ASM)
+#if defined(CRYPTOPP_DISABLE_GCM_ASM)
 # undef CRYPTOPP_X86_ASM_AVAILABLE
 # undef CRYPTOPP_X32_ASM_AVAILABLE
 # undef CRYPTOPP_X64_ASM_AVAILABLE

--- a/gcm.cpp
+++ b/gcm.cpp
@@ -12,9 +12,7 @@
 #ifndef CRYPTOPP_IMPORTS
 #ifndef CRYPTOPP_GENERATE_X64_MASM
 
-// Clang 3.3 integrated assembler crash on Linux. Other versions produce incorrect results.
-//   Clang has never handled Intel ASM very well. I wish LLVM would fix it.
-#if defined(CRYPTOPP_DISABLE_INTEL_ASM)
+#if defined(CRYPTOPP_DISABLE_GCM_ASM)
 # undef CRYPTOPP_X86_ASM_AVAILABLE
 # undef CRYPTOPP_X32_ASM_AVAILABLE
 # undef CRYPTOPP_X64_ASM_AVAILABLE

--- a/gcm.h
+++ b/gcm.h
@@ -10,6 +10,12 @@
 #include "authenc.h"
 #include "modes.h"
 
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
+# define CRYPTOPP_DISABLE_GCM_ASM 1
+#endif
+
 NAMESPACE_BEGIN(CryptoPP)
 
 /// \enum GCM_TablesOption

--- a/rijndael.cpp
+++ b/rijndael.cpp
@@ -90,11 +90,6 @@ being unloaded from L1 cache, until that round is finished.
 
 NAMESPACE_BEGIN(CryptoPP)
 
-// Clang 3.3 integrated assembler crash on Linux
-#if CRYPTOPP_BOOL_X32 || (defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30400))
-# define CRYPTOPP_DISABLE_RIJNDAEL_ASM
-#endif
-
 // Hack for http://github.com/weidai11/cryptopp/issues/42 and http://github.com/weidai11/cryptopp/issues/132
 #if (CRYPTOPP_SSE2_ASM_AVAILABLE || defined(CRYPTOPP_X64_MASM_AVAILABLE))
 # define CRYPTOPP_ALLOW_RIJNDAEL_UNALIGNED_DATA_ACCESS 1
@@ -769,7 +764,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 {
 	CRYPTOPP_UNUSED(locals); CRYPTOPP_UNUSED(k);
 
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 
 #define L_REG			esp
 #define L_INDEX(i)		(L_REG+768+i)
@@ -869,7 +864,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 	AS2(	mov		edi, [g_cacheLineSize])
 #endif
 
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 	AS2(	mov		[ecx+16*12+16*4], esp)	// save esp to L_SP
 	AS2(	lea		esp, [ecx-768])
 #endif
@@ -929,7 +924,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 	AS2(	movd	eax, xmm1)
 	AS2(	mov		al, BYTE PTR [WORD_REG(si)+15])
 	AS2(	MOVD	MM(2), eax)
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 	AS2(	mov		eax, 1)
 	AS2(	movd	mm3, eax)
 #endif
@@ -1057,7 +1052,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 	AS2(	xor		cl, ch)
 	AS2(	and		WORD_REG(cx), 255)
 	ASL(5)
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 	AS2(	paddb	MM(2), mm3)
 #else
 	AS2(	add		MM(2), 1)
@@ -1158,7 +1153,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 	AS2(	movdqu	xmm2, [WORD_REG(ax)])
 	AS2(	pxor	xmm2, xmm4)
 
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 	AS2(	movdqa	xmm0, [L_INCREMENTS])
 	AS2(	paddd	xmm0, [L_INBLOCKS])
 	AS2(	movdqa	[L_INBLOCKS], xmm0)
@@ -1206,7 +1201,7 @@ CRYPTOPP_NAKED void CRYPTOPP_FASTCALL Rijndael_Enc_AdvancedProcessBlocks(void *l
 	AS2(	movaps	[WORD_REG(ax)+4*16], xmm0)
 	AS2(	movaps	[WORD_REG(ax)+5*16], xmm0)
 	AS2(	movaps	[WORD_REG(ax)+6*16], xmm0)
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 	AS2(	mov		esp, [L_SP])
 	AS1(	emms)
 #endif

--- a/rijndael.h
+++ b/rijndael.h
@@ -13,6 +13,12 @@
 #include "seckey.h"
 #include "secblock.h"
 
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
+# define CRYPTOPP_DISABLE_RIJNDAEL_ASM 1
+#endif
+
 #if CRYPTOPP_BOOL_X64 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_ARM32 || \
 	CRYPTOPP_BOOL_ARM64 || CRYPTOPP_BOOL_PPC32 || CRYPTOPP_BOOL_PPC64
 # define CRYPTOPP_RIJNDAEL_ADVANCED_PROCESS_BLOCKS 1

--- a/salsa.h
+++ b/salsa.h
@@ -9,9 +9,10 @@
 #include "strciphr.h"
 #include "secblock.h"
 
-// "Inline assembly operands don't work with .intel_syntax", http://llvm.org/bugs/show_bug.cgi?id=24232
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
 #if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
-# define CRYPTOPP_DISABLE_SALSA_ASM
+# define CRYPTOPP_DISABLE_SALSA_ASM 1
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/sha-simd.cpp
+++ b/sha-simd.cpp
@@ -11,6 +11,13 @@
 #include "sha.h"
 #include "misc.h"
 
+#if defined(CRYPTOPP_DISABLE_SHA_ASM)
+# undef CRYPTOPP_X86_ASM_AVAILABLE
+# undef CRYPTOPP_X32_ASM_AVAILABLE
+# undef CRYPTOPP_X64_ASM_AVAILABLE
+# undef CRYPTOPP_SSE2_ASM_AVAILABLE
+#endif
+
 #if (CRYPTOPP_SHANI_AVAILABLE)
 # include <nmmintrin.h>
 # include <immintrin.h>

--- a/sha.cpp
+++ b/sha.cpp
@@ -42,13 +42,6 @@
 #include "misc.h"
 #include "cpu.h"
 
-// Clang 3.3 integrated assembler crash on Linux
-//  http://github.com/weidai11/cryptopp/issues/264
-// Clang 3.4.1 (x86) crash on FreeBSD 10.3. Clang 3.4.1 (x64) works fine.
-#if (defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30500)) || CRYPTOPP_BOOL_X32
-# define CRYPTOPP_DISABLE_SHA_ASM
-#endif
-
 #if defined(CRYPTOPP_DISABLE_SHA_ASM)
 # undef CRYPTOPP_X86_ASM_AVAILABLE
 # undef CRYPTOPP_X32_ASM_AVAILABLE

--- a/sha.h
+++ b/sha.h
@@ -11,6 +11,12 @@
 #include "config.h"
 #include "iterhash.h"
 
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
+# define CRYPTOPP_DISABLE_SHA_ASM 1
+#endif
+
 NAMESPACE_BEGIN(CryptoPP)
 
 /// \brief SHA-1 message digest

--- a/sosemanuk.h
+++ b/sosemanuk.h
@@ -10,10 +10,10 @@
 #include "strciphr.h"
 #include "secblock.h"
 
-// Clang due to "Inline assembly operands don't work with .intel_syntax"
-//   https://llvm.org/bugs/show_bug.cgi?id=24232
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
 #if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
-# define CRYPTOPP_DISABLE_SOSEMANUK_ASM
+# define CRYPTOPP_DISABLE_SOSEMANUK_ASM 1
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/sosemanuk.h
+++ b/sosemanuk.h
@@ -19,7 +19,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 
 /// \brief Sosemanuk stream cipher information
-	/// \since Crypto++ 5.5
+/// \since Crypto++ 5.5
 struct SosemanukInfo : public VariableKeyLength<16, 1, 32, 1, SimpleKeyingInterface::UNIQUE_IV, 16>
 {
 	CRYPTOPP_STATIC_CONSTEXPR const char* StaticAlgorithmName() {return "Sosemanuk";}

--- a/tiger.h
+++ b/tiger.h
@@ -10,9 +10,9 @@
 #include "config.h"
 #include "iterhash.h"
 
-// Clang 3.3 integrated assembler crash on Linux
-//  http://github.com/weidai11/cryptopp/issues/264
-#if (defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30400)) || CRYPTOPP_BOOL_X32
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
 # define CRYPTOPP_DISABLE_TIGER_ASM 1
 #endif
 

--- a/vmac.cpp
+++ b/vmac.cpp
@@ -20,7 +20,8 @@
 # pragma warning(disable: 4731)
 #endif
 
-NAMESPACE_BEGIN(CryptoPP)
+ANONYMOUS_NAMESPACE_BEGIN
+using CryptoPP::word64;
 
 #if defined(_MSC_VER) && !CRYPTOPP_BOOL_SLOW_WORD64
 #include <intrin.h>
@@ -35,11 +36,11 @@ NAMESPACE_BEGIN(CryptoPP)
 #ifdef __BORLANDC__
 #define const	// Turbo C++ 2006 workaround
 #endif
-static const word64 p64   = W64LIT(0xfffffffffffffeff);  /* 2^64 - 257 prime  */
-static const word64 m62   = W64LIT(0x3fffffffffffffff);  /* 62-bit mask       */
-static const word64 m63   = W64LIT(0x7fffffffffffffff);  /* 63-bit mask       */
-static const word64 m64   = W64LIT(0xffffffffffffffff);  /* 64-bit mask       */
-static const word64 mpoly = W64LIT(0x1fffffff1fffffff);  /* Poly key mask     */
+const word64 p64   = W64LIT(0xfffffffffffffeff);  /* 2^64 - 257 prime  */
+const word64 m62   = W64LIT(0x3fffffffffffffff);  /* 62-bit mask       */
+const word64 m63   = W64LIT(0x7fffffffffffffff);  /* 63-bit mask       */
+const word64 m64   = W64LIT(0xffffffffffffffff);  /* 64-bit mask       */
+const word64 mpoly = W64LIT(0x1fffffff1fffffff);  /* Poly key mask     */
 #ifdef __BORLANDC__
 #undef const
 #endif
@@ -48,9 +49,13 @@ static const word64 mpoly = W64LIT(0x1fffffff1fffffff);  /* Poly key mask     */
 // workaround GCC Bug 31690: ICE with const __uint128_t and C++ front-end
 #define m126				((word128(m62)<<64)|m64)
 #else
-static const word128 m126 = (word128(m62)<<64)|m64;		 /* 126-bit mask      */
+const word128 m126 = (word128(m62)<<64)|m64;		 /* 126-bit mask      */
 #endif
 #endif
+
+ANONYMOUS_NAMESPACE_END
+
+NAMESPACE_BEGIN(CryptoPP)
 
 void VMAC_Base::UncheckedSetKey(const byte *userKey, unsigned int keylength, const NameValuePairs &params)
 {
@@ -167,7 +172,7 @@ unsigned int VMAC_Base::OptimalDataAlignment() const
 		GetCipher().OptimalDataAlignment();
 }
 
-#if CRYPTOPP_SSE2_ASM_AVAILABLE && (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32)
+#if CRYPTOPP_SSE2_ASM_AVAILABLE && (CRYPTOPP_BOOL_X86)
 #if CRYPTOPP_MSC_VERSION
 # pragma warning(disable: 4731)	// frame pointer register 'ebp' modified by inline assembly code
 #endif
@@ -217,13 +222,8 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 #endif
 
 	AS2(	shr		ebx, 3)
-#if CRYPTOPP_BOOL_X32
-	AS_PUSH_IF86(	bp)
-	AS2(	sub		esp, 24)
-#else
 	AS_PUSH_IF86(	bp)
 	AS2(	sub		esp, 12)
-#endif
 	ASL(4)
 	AS2(	mov		ebp, ebx)
 	AS2(	cmp		ecx, ebx)
@@ -246,11 +246,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	pxor	mm7, mm7)
 	AS2(	movd	[esp], mm6)
 	AS2(	psrlq	mm6, 32)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+8], mm5)
-#else
 	AS2(	movd	[esp+4], mm5)
-#endif
 	AS2(	psrlq	mm5, 32)
 	AS2(	cmp		edi, ebp)
 	ASJ(	je,		1, f)
@@ -265,11 +261,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	paddq	mm5, mm2)
 	ASS(	pshufw	mm2, mm0, 1, 0, 3, 2)
 	AS2(	pmuludq	mm0, mm1)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+16], mm3)
-#else
 	AS2(	movd	[esp+8], mm3)
-#endif
 	AS2(	psrlq	mm3, 32)
 	AS2(	paddq	mm5, mm3)
 	ASS(	pshufw	mm3, mm1, 1, 0, 3, 2)
@@ -278,48 +270,28 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	pmuludq	mm3, mm4)
 	AS2(	movd	mm4, [esp])
 	AS2(	paddq	mm7, mm4)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	mm4, [esp+8])
-	AS2(	paddq	mm6, mm4)
-	AS2(	movd	mm4, [esp+16])
-#else
 	AS2(	movd	mm4, [esp+4])
 	AS2(	paddq	mm6, mm4)
 	AS2(	movd	mm4, [esp+8])
-#endif
 	AS2(	paddq	mm6, mm4)
 	AS2(	movd	[esp], mm0)
 	AS2(	psrlq	mm0, 32)
 	AS2(	paddq	mm6, mm0)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+8], mm1)
-#else
 	AS2(	movd	[esp+4], mm1)
-#endif
 	AS2(	psrlq	mm1, 32)
 	AS2(	paddq	mm5, mm1)
 	AS2(	cmp		edi, ebp)
 	ASJ(	jne,	0, b)
 	ASL(1)
 	AS2(	paddq	mm5, mm2)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+16], mm3)
-#else
 	AS2(	movd	[esp+8], mm3)
-#endif
 	AS2(	psrlq	mm3, 32)
 	AS2(	paddq	mm5, mm3)
 	AS2(	movd	mm4, [esp])
 	AS2(	paddq	mm7, mm4)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	mm4, [esp+8])
-	AS2(	paddq	mm6, mm4)
-	AS2(	movd	mm4, [esp+16])
-#else
 	AS2(	movd	mm4, [esp+4])
 	AS2(	paddq	mm6, mm4)
 	AS2(	movd	mm4, [esp+8])
-#endif
 	AS2(	paddq	mm6, mm4)
 	AS2(	lea		ebp, [8*ebx])
 	AS2(	sub		edi, ebp)		// reset edi to start of nhK
@@ -327,11 +299,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	movd	[esp], mm7)
 	AS2(	psrlq	mm7, 32)
 	AS2(	paddq	mm6, mm7)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+8], mm6)
-#else
 	AS2(	movd	[esp+4], mm6)
-#endif
 	AS2(	psrlq	mm6, 32)
 	AS2(	paddq	mm5, mm6)
 	AS2(	psllq	mm5, 2)
@@ -353,11 +321,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	movd	a0, mm0)
 	AS2(	psrlq	mm0, 32)
 	AS2(	movd	mm1, k1)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	mm2, [esp+8])
-#else
 	AS2(	movd	mm2, [esp+4])
-#endif
 	AS2(	paddq	mm1, mm2)
 	AS2(	paddq	mm0, mm1)
 	AS2(	movd	a1, mm0)
@@ -395,11 +359,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	movq	mm3, mm2)
 	AS2(	pmuludq	mm2, k3)		// a0*k3
 	AS2(	pmuludq	mm3, mm7)		// a0*k0
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	[esp+16], mm0)
-#else
 	AS2(	movd	[esp+8], mm0)
-#endif
 	AS2(	psrlq	mm0, 32)
 	AS2(	pmuludq	mm7, mm5)		// a1*k0
 	AS2(	pmuludq	mm5, k3)		// a1*k3
@@ -422,22 +382,14 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	AS2(	movd	mm1, a3)
 	AS2(	pmuludq	mm1, k2)		// a3*k2
 	AS2(	paddq	mm5, mm2)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	mm2, [esp+8])
-#else
 	AS2(	movd	mm2, [esp+4])
-#endif
 	AS2(	psllq	mm5, 1)
 	AS2(	paddq	mm0, mm5)
 	AS2(	psllq	mm4, 33)
 	AS2(	movd	a0, mm0)
 	AS2(	psrlq	mm0, 32)
 	AS2(	paddq	mm6, mm7)
-#if CRYPTOPP_BOOL_X32
-	AS2(	movd	mm7, [esp+16])
-#else
 	AS2(	movd	mm7, [esp+8])
-#endif
 	AS2(	paddq	mm0, mm6)
 	AS2(	paddq	mm0, mm2)
 	AS2(	paddq	mm3, mm1)
@@ -461,11 +413,7 @@ VMAC_Base::VHASH_Update_SSE2(const word64 *data, size_t blocksRemainingInWord64,
 	ASL(3)
 	AS2(	test	ecx, ecx)
 	ASJ(	jnz,	4, b)
-#if CRYPTOPP_BOOL_X32
-	AS2(	add		esp, 24)
-#else
 	AS2(	add		esp, 12)
-#endif
 	AS_POP_IF86(	bp)
 	AS1(	emms)
 #ifdef __GNUC__
@@ -800,7 +748,7 @@ void VMAC_Base::VHASH_Update_Template(const word64 *data, size_t blocksRemaining
 
 inline void VMAC_Base::VHASH_Update(const word64 *data, size_t blocksRemainingInWord64)
 {
-#if CRYPTOPP_SSE2_ASM_AVAILABLE && (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32)
+#if CRYPTOPP_SSE2_ASM_AVAILABLE && (CRYPTOPP_BOOL_X86)
 	if (HasSSE2())
 	{
 		VHASH_Update_SSE2(data, blocksRemainingInWord64, 0);
@@ -825,7 +773,7 @@ size_t VMAC_Base::HashMultipleBlocks(const word64 *data, size_t length)
 	return remaining;
 }
 
-static word64 L3Hash(const word64 *input, const word64 *l3Key, size_t len)
+word64 L3Hash(const word64 *input, const word64 *l3Key, size_t len)
 {
     word64 rh, rl, t, z=0;
 	word64 p1 = input[0], p2 = input[1];

--- a/vmac.cpp
+++ b/vmac.cpp
@@ -21,15 +21,17 @@
 #endif
 
 ANONYMOUS_NAMESPACE_BEGIN
-using CryptoPP::word64;
 
 #if defined(_MSC_VER) && !CRYPTOPP_BOOL_SLOW_WORD64
 #include <intrin.h>
 #endif
 
 #if defined(CRYPTOPP_WORD128_AVAILABLE) && !defined(CRYPTOPP_X64_ASM_AVAILABLE)
+using CryptoPP::word128;
+using CryptoPP::word64;
 # define VMAC_BOOL_WORD128 1
 #else
+using CryptoPP::word64;
 # define VMAC_BOOL_WORD128 0
 #endif
 

--- a/vmac.h
+++ b/vmac.h
@@ -11,10 +11,10 @@
 #include "iterhash.h"
 #include "seckey.h"
 
-// Clang 3.3 integrated assembler crash on Linux
-//  http://github.com/weidai11/cryptopp/issues/264
-#if (defined(CRYPTOPP_LLVM_CLANG_VERSION) && (CRYPTOPP_LLVM_CLANG_VERSION < 30400)) || CRYPTOPP_BOOL_X32
-# define CRYPTOPP_DISABLE_VMAC_ASM
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
+# define CRYPTOPP_DISABLE_VMAC_ASM 1
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/whrlpool.cpp
+++ b/whrlpool.cpp
@@ -73,11 +73,11 @@
 #include "misc.h"
 #include "cpu.h"
 
-// "Inline assembly operands don't work with .intel_syntax",
-//   http://llvm.org/bugs/show_bug.cgi?id=24232
-#if defined(CRYPTOPP_DISABLE_INTEL_ASM)
+#if defined(CRYPTOPP_DISABLE_WHIRLPOOL_ASM)
+# undef CRYPTOPP_X86_ASM_AVAILABLE
+# undef CRYPTOPP_X32_ASM_AVAILABLE
+# undef CRYPTOPP_X64_ASM_AVAILABLE
 # undef CRYPTOPP_SSE2_ASM_AVAILABLE
-# undef CRYPTOPP_SSSE3_ASM_AVAILABLE
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/whrlpool.cpp
+++ b/whrlpool.cpp
@@ -438,15 +438,13 @@ void Whirlpool::Transform(word64 *digest, const word64 *block)
 		AS2(	mov		WORD_REG(cx), digest)
 		AS2(	mov		WORD_REG(dx), block)
 #endif
-#if CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32
+#if CRYPTOPP_BOOL_X86
 		AS2(	mov		eax, esp)
 		AS2(	and		esp, -16)
 		AS2(	sub		esp, 16*8)
 		AS_PUSH_IF86(	ax)
 	#if CRYPTOPP_BOOL_X86
 		#define SSE2_workspace	esp+WORD_SZ
-	#elif CRYPTOPP_BOOL_X32
-		#define SSE2_workspace	esp+(WORD_SZ*2)
 	#endif
 #else
 	#define SSE2_workspace	%3

--- a/whrlpool.h
+++ b/whrlpool.h
@@ -13,6 +13,12 @@
 #include "config.h"
 #include "iterhash.h"
 
+// Clang 3.3 integrated assembler crash on Linux. Clang 3.4 due to compiler
+// error with .intel_syntax, http://llvm.org/bugs/show_bug.cgi?id=24232
+#if CRYPTOPP_BOOL_X32 || defined(CRYPTOPP_DISABLE_INTEL_ASM)
+# define CRYPTOPP_DISABLE_WHIRLPOOL_ASM 1
+#endif
+
 NAMESPACE_BEGIN(CryptoPP)
 
 /// \brief Whirlpool message digest


### PR DESCRIPTION
Also use CRYPTOPP_DISABLE_XXX_ASM consistently. The pattern is needed for Clang which still can't compile Intel assembly language. Also see http://llvm.org/bugs/show_bug.cgi?id=24232.