### PR TITLE
Fix build for MinGW due to deleted winpipes.cpp

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -771,7 +771,6 @@ SRCS := cryptlib.cpp cpu.cpp integer.cpp $(filter-out cryptlib.cpp cpu.cpp integ
 INCL := $(filter-out resource.h,$(sort $(wildcard *.h)))
 
 ifneq ($(IS_MINGW),0)
-SRCS += winpipes.cpp
 INCL += resource.h
 endif
 


### PR DESCRIPTION
On my MinGW-w64 setup, the build failed:

>mingw32-make: *** No rule to make target 'winpipes.o', needed by 'libcryptopp.a'.
>mingw32-make: Target 'default' not remade because of errors.

Looks like `winpipes.cpp` was removed in f2171cbe2 but not de-listed from the `GNUmakefile`. Remove it.