### PR TITLE
Fix unused variable warnings

### DIFF
--- a/basecode.h
+++ b/basecode.h
@@ -61,7 +61,7 @@ public:
 	/// \details padding is set to -1, which means use default padding. If not
 	///   required, then the value must be set via IsolatedInitialize().
 	BaseN_Decoder(BufferedTransformation *attachment=NULLPTR)
-		: m_lookup(NULLPTR), m_padding(0), m_bitsPerChar(0)
+		: m_lookup(NULLPTR), m_bitsPerChar(0)
 		, m_outputBlockSize(0), m_bytePos(0), m_bitPos(0)
 			{Detach(attachment);}
 
@@ -74,7 +74,7 @@ public:
 	/// \details padding is set to -1, which means use default padding. If not
 	///   required, then the value must be set via IsolatedInitialize().
 	BaseN_Decoder(const int *lookup, int log2base, BufferedTransformation *attachment=NULLPTR)
-		: m_lookup(NULLPTR), m_padding(0), m_bitsPerChar(0)
+		: m_lookup(NULLPTR), m_bitsPerChar(0)
 		, m_outputBlockSize(0), m_bytePos(0), m_bitPos(0)
 	{
 		Detach(attachment);
@@ -98,7 +98,7 @@ public:
 
 private:
 	const int *m_lookup;
-	int m_padding, m_bitsPerChar, m_outputBlockSize;
+	int m_bitsPerChar, m_outputBlockSize;
 	int m_bytePos, m_bitPos;
 	SecByteBlock m_outBuf;
 };

--- a/fips140.cpp
+++ b/fips140.cpp
@@ -36,10 +36,12 @@ PowerUpSelfTestStatus CRYPTOPP_API GetPowerUpSelfTestStatus()
 	return g_powerUpSelfTestStatus;
 }
 
+#if CRYPTOPP_ENABLE_COMPLIANCE_WITH_FIPS_140_2
 // One variable for all threads for compatibility. Previously this
 // was a ThreadLocalStorage variable, which is per-thread. Also see
 // https://github.com/weidai11/cryptopp/issues/208
 static bool s_inProgress = false;
+#endif
 
 bool PowerUpSelfTestInProgressOnThisThread()
 {

--- a/rijndael.cpp
+++ b/rijndael.cpp
@@ -120,15 +120,6 @@ static volatile bool s_TeFilled = false, s_TdFilled = false;
 
 ANONYMOUS_NAMESPACE_BEGIN
 
-CRYPTOPP_ALIGN_DATA(16)
-const word32 s_one[] = {0, 0, 0, 1<<24};
-
-/* for 128-bit blocks, Rijndael never uses more than 10 rcon values */
-CRYPTOPP_ALIGN_DATA(16)
-const word32 s_rconLE[] = {
-	0x01, 0x02, 0x04, 0x08,	0x10, 0x20, 0x40, 0x80,	0x1B, 0x36
-};
-
 #if CRYPTOPP_BOOL_X64 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X86
 
 // Determine whether the range between begin and end overlaps


### PR DESCRIPTION
Observed some warnings when compiling in XCode 9.4.1

```
In file included from cryptopp/basecode.cpp:16:
cryptopp/basecode.h:101:6: warning: private field 'm_padding' is not used [-Wunused-private-field]
        int m_padding, m_bitsPerChar, m_outputBlockSize;
            ^
1 warning generated.

cryptopp/fips140.cpp:42:13: warning: unused variable 's_inProgress' [-Wunused-variable]
static bool s_inProgress = false;
            ^
1 warning generated.

cryptopp/rijndael.cpp:124:14: warning: unused variable 's_one' [-Wunused-const-variable]
const word32 s_one[] = {0, 0, 0, 1<<24};
             ^
cryptopp/rijndael.cpp:128:14: warning: unused variable 's_rconLE' [-Wunused-const-variable]
const word32 s_rconLE[] = {
             ^
2 warnings generated.
```

