### PR TITLE
android: use CC to compile cpu-features

### DIFF
--- a/GNUmakefile-cross
+++ b/GNUmakefile-cross
@@ -524,15 +524,15 @@ ifeq ($(HAS_SOLIB_VERSION),1)
 libcryptopp.so: libcryptopp.so$(SOLIB_VERSION_SUFFIX)
 endif
 
-libcryptopp.so$(SOLIB_VERSION_SUFFIX): $(LIBOBJS)
-	$(CXX) -shared $(SOLIB_FLAGS) -o $@ $(strip $(CXXFLAGS)) -Wl,--exclude-libs,ALL $(LIBOBJS) $(LDFLAGS) $(LDLIBS)
+libcryptopp.so$(SOLIB_VERSION_SUFFIX): $(LIBOBJS) $(AOSP_CPU_OBJ)
+	$(CXX) -shared $(SOLIB_FLAGS) -o $@ $(strip $(CXXFLAGS)) -Wl,--exclude-libs,ALL $(LIBOBJS) $(AOSP_CPU_OBJ) $(LDFLAGS) $(LDLIBS)
 ifeq ($(HAS_SOLIB_VERSION),1)
 	-$(LN) libcryptopp.so$(SOLIB_VERSION_SUFFIX) libcryptopp.so
 	-$(LN) libcryptopp.so$(SOLIB_VERSION_SUFFIX) libcryptopp.so$(SOLIB_COMPAT_SUFFIX)
 endif
 
-libcryptopp.dylib: $(LIBOBJS)
-	$(CXX) -dynamiclib -o $@ $(strip $(CXXFLAGS)) -install_name "$@" -current_version "$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)" -compatibility_version "$(LIB_MAJOR).$(LIB_MINOR)" -headerpad_max_install_names $(LDFLAGS) $(LIBOBJS)
+libcryptopp.dylib: $(LIBOBJS) $(AOSP_CPU_OBJ)
+	$(CXX) -dynamiclib -o $@ $(strip $(CXXFLAGS)) -install_name "$@" -current_version "$(LIB_MAJOR).$(LIB_MINOR).$(LIB_PATCH)" -compatibility_version "$(LIB_MAJOR).$(LIB_MINOR)" -headerpad_max_install_names $(LDFLAGS) $(LIBOBJS) $(AOSP_CPU_OBJ)
 
 cryptest.exe: libcryptopp.a $(TESTOBJS)
 	$(CXX) -o $@ $(strip $(CXXFLAGS)) $(TESTOBJS) ./libcryptopp.a $(LDFLAGS) $(LDLIBS)
@@ -565,7 +565,7 @@ ifeq ($(wildcard GNUmakefile.deps),GNUmakefile.deps)
 endif # Dependencies
 
 cpu-features.o: cpu-features.h cpu-features.c
-	$(CXX) $(strip $(CXXFLAGS) -fpermissive -c) cpu-features.c
+	$(CC) $(strip $(CXXFLAGS) -fpermissive -c) cpu-features.c
 
 # Cryptogams ARM asm implementation.
 aes-armv4.o : aes-armv4.S


### PR DESCRIPTION
Hello,

I recently had to build cryptopp on android, and I encountered some build issues.

This PR contains changes that correct some of those issues.

Note: Tested using [android-ndk-r18b-linux-x86_64](https://dl.google.com/android/repository/android-ndk-r18b-linux-x86_64.zip) on Linux. Built for arm64.

## Detail

### Compiling C as C++
The android NDK [has migrated from gcc to clang](https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md).

One of the first issue I had came from: 

```
	$(CXX) $(strip $(CXXFLAGS) -fpermissive -c) cpu-features.c
```
Because clang would try to compile `cpu-features.c` as C++, which of course yields a lot of errors.

Changing to `$(CC)` fixed the problem.

### Missing cpu-feature 
Once compiled and installed, my android application would fail to load the library with the following error message:

```
2018-10-30 21:04:31.371 15477-15477/[redacted] E/AndroidRuntime: FATAL EXCEPTION: main
    Process: [redacted], PID: 15477
    java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "android_getCpuFeatures" referenced by "[redacted]/lib/arm64/libcryptopp.so"...
        at java.lang.Runtime.loadLibrary0(Runtime.java:1016)
        at java.lang.System.loadLibrary(System.java:1657)
        at [redacted].MainActivity.<clinit>(MainActivity.java:13)
``` 

That's because the object `$(AOSP_CPU_OBJ)` is omitted from the rule `libcryptopp.so`.

Adding the object fixed that problem.