### PR TITLE
Misc warning fixes

### DIFF
--- a/des.cpp
+++ b/des.cpp
@@ -284,14 +284,16 @@ namespace {
 void RawDES::RawSetKey(CipherDir dir, const byte *key)
 {
 #if (_MSC_VER >= 1600) || (__cplusplus >= 201103L)
-# define register /* Define to nothing for C++11 and above */
+# define REGISTER /* Define to nothing for C++11 and above */
+#else
+# define REGISTER register
 #endif
 
 	SecByteBlock buffer(56+56+8);
 	byte *const pc1m=buffer;                 /* place to modify pc1 into */
 	byte *const pcr=pc1m+56;                 /* place to rotate pc1 into */
 	byte *const ks=pcr+56;
-	register int i,j,l;
+	REGISTER int i,j,l;
 	int m;
 
 	for (j=0; j<56; j++) {          /* convert pc1 to bits of key */

--- a/filters.h
+++ b/filters.h
@@ -1100,7 +1100,7 @@ CRYPTOPP_DLL_TEMPLATE_CLASS StringSinkTemplate<std::string>;
 
 /// \brief Append input to a std::vector<byte> object
 /// \details VectorSink is a typedef for StringSinkTemplate<std::vector<byte> >.
-DOCUMENTED_TYPEDEF(StringSinkTemplate<std::vector<byte> >, VectorSink);
+DOCUMENTED_TYPEDEF(StringSinkTemplate<std::vector<byte> >, VectorSink)
 CRYPTOPP_DLL_TEMPLATE_CLASS StringSinkTemplate<std::vector<byte> >;
 
 /// \brief Incorporates input into RNG as additional entropy

--- a/gf2n.h
+++ b/gf2n.h
@@ -357,13 +357,13 @@ class CRYPTOPP_DLL GF2NPP : public GF2NP
 public:
 	// polynomial modulus = x^t0 + x^t1 + x^t2 + x^t3 + x^t4, t0 > t1 > t2 > t3 > t4
 	GF2NPP(unsigned int t0, unsigned int t1, unsigned int t2, unsigned int t3, unsigned int t4)
-		: GF2NP(PolynomialMod2::Pentanomial(t0, t1, t2, t3, t4)), t0(t0), t1(t1), t2(t2), t3(t3) {}
+		: GF2NP(PolynomialMod2::Pentanomial(t0, t1, t2, t3, t4)), t1(t1), t2(t2), t3(t3) {}
 
 	GF2NP * Clone() const {return new GF2NPP(*this);}
 	void DEREncode(BufferedTransformation &bt) const;
 
 private:
-	unsigned int t0, t1, t2, t3;
+	unsigned int t1, t2, t3;
 };
 
 // construct new GF2NP from the ASN.1 sequence Characteristic-two


### PR DESCRIPTION
Fix some minor warnings on Clang and GCC that show up when compiling Crypto++ with `-Wall -Wextra -pedantic`.

GCC also warns about the OMP pragmas in `nbtheory.cpp`, `rw.cpp`, and `scrypt.cpp` being unknown pragmas, and guarding those with `#if defined(_OPENMP)` does get rid of the warnings, however it also makes the code messier so I opted for taking the `-Wno-unknown-pragmas` route locally rather than checking those in.