### PR TITLE
Use SSE2 intrinsics header in sse_simd.cpp only if needed

### DIFF
--- a/sse_simd.cpp
+++ b/sse_simd.cpp
@@ -24,7 +24,9 @@
 
 // Needed by SunCC and MSVC
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-# include <emmintrin.h>
+# if !defined(CRYPTOPP_NO_CPU_FEATURE_PROBES) && !CRYPTOPP_SSE2_ASM_AVAILABLE && CRYPTOPP_SSE2_INTRIN_AVAILABLE
+#  include <emmintrin.h>
+# endif
 #endif
 
 // Squash MS LNK4221 and libtool warnings


### PR DESCRIPTION
Embarcadero C++Builder v10.3 [has a bug](https://quality.embarcadero.com/browse/RSP-22883) where its old Intel intrinsics headers try to use retired Clang builtins and fail to compile. In devising a workaround with `-DCRYPTOPP_DISABLE_ASM`, I found that `sse_simd.cpp` includes `<emmintrin.h>` even when its code doesn't need the intrinsics.

How am I getting `sse_simd.cpp` into my 32-bit build?
  - My code is using `CryptoPP::ECB_Mode<CryptoPP::AES>::Encryption` via `aes.h`, which includes `rijndael.h`. This declares some class methods that are defined in `rijndael.cpp`.
    - `rinjdael.cpp` (via `cpu.h`) needs `g_x86DetectionDone` and `DetectX86Features()`, which are defined in `cpu.cpp`.
      - `cpu.cpp` needs `CPU_ProbeSSE2()`, which is defined in `sse_simd.cpp`.

With this patch, `-DCRYPTOPP_DISABLE_ASM` will be a sufficient workaround because `CRYPTOPP_SSE2_INTRIN_AVAILABLE` is derived from it in `config.h`.