### PR TITLE
Avoid Clang integrated assembler on macOS PowerPC (MacPorts) GCC

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -100,9 +100,9 @@ ifeq ($(wildcard adhoc.cpp),)
 $(shell cp adhoc.cpp.proto adhoc.cpp)
 endif
 
-# Tell MacPorts and Homebrew GCC to use Clang integrated assembler
+# Tell MacPorts and Homebrew GCC to use Clang integrated assembler (only on Intel-based Macs)
 #   http://github.com/weidai11/cryptopp/issues/190
-ifeq ($(GCC_COMPILER)$(OSXPORT_COMPILER),11)
+ifeq ($(GCC_COMPILER)$(OSXPORT_COMPILER)$(IS_PPC32)$(IS_PPC64),1100)
   ifeq ($(findstring -Wa,-q,$(CXXFLAGS)),)
     CXXFLAGS += -Wa,-q
   endif


### PR DESCRIPTION
On my iBook G3 Indigo ([PowerPC 750CXe](https://en.wikipedia.org/wiki/IBook#Models)) running OSX Tiger 10.4.11, XCode 2.5, MacPorts 2.5.4, and `sudo port -v install git gcc7 gmake wget bash`, trying to build Crypto++ resulted in this error:

```
$ export CXX=/opt/local/bin/g++-mp-7
$ gmake deps
Using testing flags: -Wa,-q
g++ -Wa,-q -DCRYPTOPP_DISABLE_ALTIVEC -fPIC -pipe -DCRYPTOPP_DISABLE_ASM -MM *.cpp > GNUmakefile.deps
$ gmake
Using testing flags: -Wa,-q
g++ -Wa,-q -DCRYPTOPP_DISABLE_ALTIVEC -fPIC -pipe -c cryptlib.cpp
/opt/local/bin/as: can't specifiy -q with -arch ppc
gmake: *** [GNUmakefile:1573: cryptlib.o] Error 2
gmake: Target 'default' not remade because of errors.
```

The Clang integrated assembler seems to be used for targeting modern Intel instruction sets, because the default GCC Assembler (v1.38) is too old. **Change that logic to not be activated on PowerPC systems.**

For reference, on my system:

```
$ /opt/local/bin/as -v < /dev/null
Apple Inc version cctools-921, GNU assembler version 1.38
$ /opt/local/bin/as -qv < /dev/null
/opt/local/bin/as: can't specifiy -q with -arch ppc
```

and:

```
$ /usr/bin/as -v < /dev/null
Apple Computer, Inc. version cctools-622.9~2, GNU assembler version 1.38
$ /usr/bin/as -qv < /dev/null
/usr/bin/../libexec/gcc/darwin/ppc/as: I don't understand 'q' flag!
Apple Computer, Inc. version cctools-622.9~2, GNU assembler version 1.38
```