### PR TITLE
Fix clang warnings

### DIFF
--- a/authenc.h
+++ b/authenc.h
@@ -60,7 +60,7 @@ protected:
 
 	void AuthenticateData(const byte *data, size_t len);
 	const SymmetricCipher & GetSymmetricCipher() const
-		{return const_cast<AuthenticatedSymmetricCipherBase *>(this)->AccessSymmetricCipher();};
+		{return const_cast<AuthenticatedSymmetricCipherBase *>(this)->AccessSymmetricCipher();}
 
 	virtual SymmetricCipher & AccessSymmetricCipher() =0;
 	virtual bool AuthenticationIsOnPlaintext() const =0;

--- a/ccm.h
+++ b/ccm.h
@@ -73,7 +73,7 @@ protected:
 	virtual BlockCipher & AccessBlockCipher() =0;
 	virtual int DefaultDigestSize() const =0;
 
-	const BlockCipher & GetBlockCipher() const {return const_cast<CCM_Base *>(this)->AccessBlockCipher();};
+	const BlockCipher & GetBlockCipher() const {return const_cast<CCM_Base *>(this)->AccessBlockCipher();}
 	byte *CBC_Buffer() {return m_buffer+REQUIRED_BLOCKSIZE;}
 
 	enum {REQUIRED_BLOCKSIZE = 16};

--- a/gcm.h
+++ b/gcm.h
@@ -80,7 +80,7 @@ protected:
 	virtual BlockCipher & AccessBlockCipher() =0;
 	virtual GCM_TablesOption GetTablesOption() const =0;
 
-	const BlockCipher & GetBlockCipher() const {return const_cast<GCM_Base *>(this)->AccessBlockCipher();};
+	const BlockCipher & GetBlockCipher() const {return const_cast<GCM_Base *>(this)->AccessBlockCipher();}
 	byte *HashBuffer() {return m_buffer+REQUIRED_BLOCKSIZE;}
 	byte *HashKey() {return m_buffer+2*REQUIRED_BLOCKSIZE;}
 	byte *MulTable() {return m_buffer+3*REQUIRED_BLOCKSIZE;}

--- a/misc.h
+++ b/misc.h
@@ -617,7 +617,7 @@ template <class T1, class T2> inline const T1 UnsignedMin(const T1& a, const T2&
 template <class T1, class T2>
 inline bool SafeConvert(T1 from, T2 &to)
 {
-	to = (T2)from;
+	to = static_cast<T2>(from);
 	if (from != to || (from > 0) != (to > 0))
 		return false;
 	return true;

--- a/pubkey.h
+++ b/pubkey.h
@@ -379,7 +379,7 @@ public:
 		{
 			static HashIdentifier CRYPTOPP_API Lookup()
 			{
-				return HashIdentifier((const byte *)NULLPTR, 0);
+				return HashIdentifier(static_cast<const byte *>(NULLPTR), 0);
 			}
 		};
 	};

--- a/secblock.h
+++ b/secblock.h
@@ -421,7 +421,7 @@ public:
 			CRYPTOPP_ASSERT(size <= S);
 			CRYPTOPP_ASSERT(m_allocated);
 			m_allocated = false;
-			SecureWipeArray((pointer)ptr, size);
+			SecureWipeArray(reinterpret_cast<pointer>(ptr), size);
 		}
 		else
 			m_fallbackAllocator.deallocate(ptr, size);
@@ -503,7 +503,7 @@ private:
 	// The library is OK but users may hit it. So we need to guard
 	// for a large T, and that is what PAD achieves.
 	T* GetAlignedArray() {
-		T* p_array = (T*)(void*)(((byte*)m_array) + (0-(size_t)m_array)%16);
+		T* p_array = reinterpret_cast<T*>(static_cast<void*>((reinterpret_cast<byte*>(m_array)) + (0-reinterpret_cast<size_t>(m_array))%16));
 		// Verify the 16-byte alignment
 		CRYPTOPP_ASSERT(IsAlignedOn(p_array, 16));
 		// Verify allocated array with pad is large enough.

--- a/seckey.h
+++ b/seckey.h
@@ -265,7 +265,7 @@ public:
 	/// \brief The maximum key length used by the algorithm
 	/// \returns maximum key length used by the algorithm, in bytes
 	size_t MaxKeyLength() const
-		{return (size_t)INFO::MAX_KEYLENGTH;}
+		{return static_cast<size_t>(INFO::MAX_KEYLENGTH);}
 
 	/// \brief The default key length used by the algorithm
 	/// \returns default key length used by the algorithm, in bytes
@@ -286,7 +286,7 @@ public:
 	/// \details The default value is NOT_RESYNCHRONIZABLE. See IV_Requirement
 	///  in cryptlib.h for allowed values.
 	SimpleKeyingInterface::IV_Requirement IVRequirement() const
-		{return (SimpleKeyingInterface::IV_Requirement)INFO::IV_REQUIREMENT;}
+		{return static_cast<SimpleKeyingInterface::IV_Requirement>(INFO::IV_REQUIREMENT);}
 
 	/// \brief The initialization vector length for the algorithm
 	/// \details IVSize is provided in bytes, not bits. The default implementation uses


### PR DESCRIPTION
- remove superfluous semicola to fix -Wextra-semi
- use C++ casts to fix -Wold-style-cast