### PR TITLE
Clear alignment warnings on ARM 32-bit platforms

### DIFF
--- a/blake2.cpp
+++ b/blake2.cpp
@@ -43,16 +43,17 @@
 # undef CRYPTOPP_ALTIVEC_AVAILABLE
 #endif
 
+// Can't use GetAlignmentOf<word64>() because of C++11 and constexpr
+// Can use 'const unsigned int' because of MSVC
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-static const unsigned int ALIGN_SPEC32=16;
-static const unsigned int ALIGN_SPEC64=16;
+# define ALIGN_SPEC32 16
+# define ALIGN_SPEC64 16
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-static const unsigned int ALIGN_SPEC32=alignof(CryptoPP::word32);
-static const unsigned int ALIGN_SPEC64=alignof(CryptoPP::word64);
+# define ALIGN_SPEC32 alignof(CryptoPP::word32)
+# define ALIGN_SPEC64 alignof(CryptoPP::word64)
 #else
-// Can't use GetAlignmentOf<word64>() because of C++11 constexpr
-static const unsigned int ALIGN_SPEC32=4;
-static const unsigned int ALIGN_SPEC64=8;
+# define ALIGN_SPEC32 4
+# define ALIGN_SPEC64 8
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/blake2.cpp
+++ b/blake2.cpp
@@ -44,15 +44,15 @@
 #endif
 
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-const unsigned int ALIGN_SPEC32=16;
-const unsigned int ALIGN_SPEC64=16;
+static const unsigned int ALIGN_SPEC32=16;
+static const unsigned int ALIGN_SPEC64=16;
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-const unsigned int ALIGN_SPEC32=alignof(CryptoPP::word32);
-const unsigned int ALIGN_SPEC64=alignof(CryptoPP::word64);
+static const unsigned int ALIGN_SPEC32=alignof(CryptoPP::word32);
+static const unsigned int ALIGN_SPEC64=alignof(CryptoPP::word64);
 #else
 // Can't use GetAlignmentOf<word64>() because of C++11 constexpr
-const unsigned int ALIGN_SPEC32=4;
-const unsigned int ALIGN_SPEC64=8;
+static const unsigned int ALIGN_SPEC32=4;
+static const unsigned int ALIGN_SPEC64=8;
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -927,8 +927,12 @@ curve25519_contract(byte out[32], const bignum25519 in) {
 
 /* out = (flag) ? in : out */
 inline void
-curve25519_move_conditional_bytes(byte out[96], const byte in[96], word32 flag) {
-#if defined(__GNUC__) && defined(__i686__)
+curve25519_move_conditional_bytes(byte out[96], const byte in[96], word32 flag)
+{
+    // TODO: enable this code path once we can test and benchmark it.
+    // It is about 48 insns shorter, it avoids punning which may be UB,
+    // and it is guaranteed constant time.
+#if defined(__GNUC__) && defined(__i686__) && 0
     const word32 iter = 96/sizeof(word32);
     word32* outl = reinterpret_cast<word32*>(out);
     const word32* inl = reinterpret_cast<const word32*>(in);

--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -40,12 +40,12 @@ extern const char DONNA32_FNAME[] = __FILE__;
 ANONYMOUS_NAMESPACE_BEGIN
 
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-const unsigned int ALIGN_SPEC=16;
+static const unsigned int ALIGN_SPEC=16;
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
+static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
 #else
 // Can't use GetAlignmentOf<word32>() because of C++11 constexpr
-const unsigned int ALIGN_SPEC=4;
+static const unsigned int ALIGN_SPEC=4;
 #endif
 
 ANONYMOUS_NAMESPACE_END

--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -39,13 +39,14 @@ extern const char DONNA32_FNAME[] = __FILE__;
 
 ANONYMOUS_NAMESPACE_BEGIN
 
+// Can't use GetAlignmentOf<word32>() because of C++11 and constexpr
+// Can use 'const unsigned int' because of MSVC
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-static const unsigned int ALIGN_SPEC=16;
+# define ALIGN_SPEC 16
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
+# define ALIGN_SPEC alignof(CryptoPP::word32)
 #else
-// Can't use GetAlignmentOf<word32>() because of C++11 constexpr
-static const unsigned int ALIGN_SPEC=4;
+# define ALIGN_SPEC 4
 #endif
 
 ANONYMOUS_NAMESPACE_END
@@ -927,6 +928,28 @@ curve25519_contract(byte out[32], const bignum25519 in) {
 /* out = (flag) ? in : out */
 inline void
 curve25519_move_conditional_bytes(byte out[96], const byte in[96], word32 flag) {
+#if defined(__GNUC__) && defined(__i686__)
+    const word32 iter = 96/sizeof(word32);
+    word32* outl = reinterpret_cast<word32*>(out);
+    const word32* inl = reinterpret_cast<const word32*>(in);
+    word32 idx=0, val;
+
+    __asm__ __volatile__ (
+        ".att_syntax                         ;\n"
+        "cmpl     $0, %[flag]                ;\n"  // compare, set ZERO flag
+        "movl     %[iter], %%ecx             ;\n"  // load iteration count
+        "1:                                  ;\n"
+        "  movl     (%[idx],%[out]), %[val]  ;\n"  // val = out[idx]
+        "  cmovnzl  (%[idx],%[in]), %[val]   ;\n"  // copy in[idx] to val if NZ
+        "  movl     %[val], (%[idx],%[out])  ;\n"  // out[idx] = val
+        "  leal     4(%[idx]), %[idx]        ;\n"  // increment index
+        "  loopnz   1b                       ;\n"  // does not affect flags
+        : [out] "+S" (outl), [in] "+D" (inl),
+          [idx] "+b" (idx), [val] "=r" (val)
+        : [flag] "g" (flag), [iter] "I" (iter)
+        : "ecx", "memory", "cc"
+    );
+#else
     const word32 nb = flag - 1, b = ~nb;
     const word32 *inl = (const word32 *)in;
     word32 *outl = (word32 *)out;
@@ -954,6 +977,7 @@ curve25519_move_conditional_bytes(byte out[96], const byte in[96], word32 flag) 
     outl[21] = (outl[21] & nb) | (inl[21] & b);
     outl[22] = (outl[22] & nb) | (inl[22] & b);
     outl[23] = (outl[23] & nb) | (inl[23] & b);
+#endif
 }
 
 /* if (iswap) swap(a, b) */

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -749,8 +749,12 @@ curve25519_contract(byte *out, const bignum25519 input) {
 
 /* out = (flag) ? in : out */
 inline void
-curve25519_move_conditional_bytes(byte out[96], const byte in[96], word64 flag) {
-#if defined(__GNUC__) && defined(__x86_64__)
+curve25519_move_conditional_bytes(byte out[96], const byte in[96], word64 flag)
+{
+    // TODO: enable this code path once we can test and benchmark it.
+    // It is about 24 insns shorter, it avoids punning which may be UB,
+    // and it is guaranteed constant time.
+#if defined(__GNUC__) && defined(__x86_64__) && 0
     const word32 iter = 96/sizeof(word64);
     word64* outq = reinterpret_cast<word64*>(out);
     const word64* inq = reinterpret_cast<const word64*>(in);

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -39,13 +39,14 @@ extern const char DONNA64_FNAME[] = __FILE__;
 
 ANONYMOUS_NAMESPACE_BEGIN
 
+// Can't use GetAlignmentOf<word64>() because of C++11 and constexpr
+// Can use 'const unsigned int' because of MSVC
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-static const unsigned int ALIGN_SPEC=16;
+# define ALIGN_SPEC 16
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word64);
+# define ALIGN_SPEC alignof(CryptoPP::word64)
 #else
-// Can't use GetAlignmentOf<word64>() because of C++11 constexpr
-static const unsigned int ALIGN_SPEC=8;
+# define ALIGN_SPEC 8
 #endif
 
 ANONYMOUS_NAMESPACE_END
@@ -749,6 +750,28 @@ curve25519_contract(byte *out, const bignum25519 input) {
 /* out = (flag) ? in : out */
 inline void
 curve25519_move_conditional_bytes(byte out[96], const byte in[96], word64 flag) {
+#if defined(__GNUC__) && defined(__x86_64__)
+    const word32 iter = 96/sizeof(word64);
+    word64* outq = reinterpret_cast<word64*>(out);
+    const word64* inq = reinterpret_cast<const word64*>(in);
+    word64 idx=0, val;
+
+    __asm__ __volatile__ (
+        ".att_syntax                         ;\n"
+        "cmpq     $0, %[flag]                ;\n"  // compare, set ZERO flag
+        "movq     %[iter], %%rcx             ;\n"  // load iteration count
+        "1:                                  ;\n"
+        "  movq     (%[idx],%[out]), %[val]  ;\n"  // val = out[idx]
+        "  cmovnzq  (%[idx],%[in]), %[val]   ;\n"  // copy in[idx] to val if NZ
+        "  movq     %[val], (%[idx],%[out])  ;\n"  // out[idx] = val
+        "  leaq     8(%[idx]), %[idx]        ;\n"  // increment index
+        "  loopnz   1b                       ;\n"  // does not affect flags
+        : [out] "+S" (outq), [in] "+D" (inq),
+          [idx] "+b" (idx), [val] "=r" (val)
+        : [flag] "g" (flag), [iter] "I" (iter)
+        : "rcx", "memory", "cc"
+    );
+#else
     const word64 nb = flag - 1, b = ~nb;
     const word64 *inq = (const word64 *)in;
     word64 *outq = (word64 *)out;
@@ -764,6 +787,7 @@ curve25519_move_conditional_bytes(byte out[96], const byte in[96], word64 flag) 
     outq[9] = (outq[9] & nb) | (inq[9] & b);
     outq[10] = (outq[10] & nb) | (inq[10] & b);
     outq[11] = (outq[11] & nb) | (inq[11] & b);
+#endif
 }
 
 /* if (iswap) swap(a, b) */

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -40,12 +40,12 @@ extern const char DONNA64_FNAME[] = __FILE__;
 ANONYMOUS_NAMESPACE_BEGIN
 
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-const unsigned int ALIGN_SPEC=16;
+static const unsigned int ALIGN_SPEC=16;
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-const unsigned int ALIGN_SPEC=alignof(CryptoPP::word64);
+static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word64);
 #else
 // Can't use GetAlignmentOf<word64>() because of C++11 constexpr
-const unsigned int ALIGN_SPEC=8;
+static const unsigned int ALIGN_SPEC=8;
 #endif
 
 ANONYMOUS_NAMESPACE_END

--- a/salsa.cpp
+++ b/salsa.cpp
@@ -29,12 +29,12 @@
 ANONYMOUS_NAMESPACE_BEGIN
 
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-const unsigned int ALIGN_SPEC=16;
+static const unsigned int ALIGN_SPEC=16;
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
+static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
 #else
 // Can't use GetAlignmentOf<word32>() because of C++11 constexpr
-const unsigned int ALIGN_SPEC=4;
+static const unsigned int ALIGN_SPEC=4;
 #endif
 
 ANONYMOUS_NAMESPACE_END

--- a/salsa.cpp
+++ b/salsa.cpp
@@ -28,13 +28,14 @@
 
 ANONYMOUS_NAMESPACE_BEGIN
 
+// Can't use GetAlignmentOf<word32>() because of C++11 and constexpr
+// Can use 'const unsigned int' because of MSVC
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
-static const unsigned int ALIGN_SPEC=16;
+# define ALIGN_SPEC 16
 #elif (CRYPTOPP_CXX11_ALIGNOF)
-static const unsigned int ALIGN_SPEC=alignof(CryptoPP::word32);
+# define ALIGN_SPEC alignof(CryptoPP::word32)
 #else
-// Can't use GetAlignmentOf<word32>() because of C++11 constexpr
-static const unsigned int ALIGN_SPEC=4;
+# define ALIGN_SPEC 4
 #endif
 
 ANONYMOUS_NAMESPACE_END


### PR DESCRIPTION
The first try used `const` and `static const`. VS2013 and below could not compile the file. We had to switch to defines.

Apparently Microsoft thinks the file can change or the `const int` can change between the time the file is saved and compiled. It defies everything we know about the laws of the physical universe, but hey...