### PR TITLE
Remove C++11 constexpr code for CRYPTOPP_ALIGN_DATA

### DIFF
--- a/blake2.cpp
+++ b/blake2.cpp
@@ -44,13 +44,10 @@
 #endif
 
 // Can't use GetAlignmentOf<word64>() because of C++11 and constexpr
-// Can use 'const unsigned int' because of MSVC
+// Can use 'const unsigned int' because of MSVC 2013
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
 # define ALIGN_SPEC32 16
 # define ALIGN_SPEC64 16
-#elif (CRYPTOPP_CXX11_ALIGNOF)
-# define ALIGN_SPEC32 alignof(CryptoPP::word32)
-# define ALIGN_SPEC64 alignof(CryptoPP::word64)
 #else
 # define ALIGN_SPEC32 4
 # define ALIGN_SPEC64 8

--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -40,11 +40,9 @@ extern const char DONNA32_FNAME[] = __FILE__;
 ANONYMOUS_NAMESPACE_BEGIN
 
 // Can't use GetAlignmentOf<word32>() because of C++11 and constexpr
-// Can use 'const unsigned int' because of MSVC
+// Can use 'const unsigned int' because of MSVC 2013
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
 # define ALIGN_SPEC 16
-#elif (CRYPTOPP_CXX11_ALIGNOF)
-# define ALIGN_SPEC alignof(CryptoPP::word32)
 #else
 # define ALIGN_SPEC 4
 #endif

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -40,11 +40,9 @@ extern const char DONNA64_FNAME[] = __FILE__;
 ANONYMOUS_NAMESPACE_BEGIN
 
 // Can't use GetAlignmentOf<word64>() because of C++11 and constexpr
-// Can use 'const unsigned int' because of MSVC
+// Can use 'const unsigned int' because of MSVC 2013
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
 # define ALIGN_SPEC 16
-#elif (CRYPTOPP_CXX11_ALIGNOF)
-# define ALIGN_SPEC alignof(CryptoPP::word64)
 #else
 # define ALIGN_SPEC 8
 #endif

--- a/salsa.cpp
+++ b/salsa.cpp
@@ -29,11 +29,9 @@
 ANONYMOUS_NAMESPACE_BEGIN
 
 // Can't use GetAlignmentOf<word32>() because of C++11 and constexpr
-// Can use 'const unsigned int' because of MSVC
+// Can use 'const unsigned int' because of MSVC 2013
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
 # define ALIGN_SPEC 16
-#elif (CRYPTOPP_CXX11_ALIGNOF)
-# define ALIGN_SPEC alignof(CryptoPP::word32)
 #else
 # define ALIGN_SPEC 4
 #endif


### PR DESCRIPTION
I don't have faith in it even though it has tested good so far.