### PR TITLE
config: guard CRYPTOPP_SSE2_INTRIN_AVAILABLE with CRYPTOPP_DISABLE_SSE2

### DIFF
--- a/config_asm.h
+++ b/config_asm.h
@@ -110,7 +110,7 @@
 #endif
 
 // 32-bit SunCC does not enable SSE2 by default.
-#if !defined(CRYPTOPP_DISABLE_ASM) && (defined(_MSC_VER) || CRYPTOPP_GCC_VERSION >= 30300 || defined(__SSE2__) || (__SUNPRO_CC >= 0x5100))
+#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_SSE2) && (defined(_MSC_VER) || CRYPTOPP_GCC_VERSION >= 30300 || defined(__SSE2__) || (__SUNPRO_CC >= 0x5100))
 	#define CRYPTOPP_SSE2_INTRIN_AVAILABLE 1
 #endif
 


### PR DESCRIPTION
Build fails for CPU that does not support SSE2 and while CRYPTOPP_DISABLE_SSE2 is defined.