### PR TITLE
Use fixed size temporary in LC_RNG for consistency across platforms

### DIFF
--- a/rng.cpp
+++ b/rng.cpp
@@ -43,7 +43,7 @@ void LC_RNG::GenerateBlock(byte *output, size_t size)
 		word32 hi = seed/q;
 		word32 lo = seed%q;
 
-		long test = a*lo - r*hi;
+		sword64 test = a*lo - r*hi;
 
 		if (test > 0)
 			seed = test;


### PR DESCRIPTION
`long` variables are 8 bytes on 64 bit Linux and 4 bytes on 64 bit Windows (Ref [Intel](https://software.intel.com/en-us/articles/size-of-long-integer-type-on-different-architecture-and-os)). This leads to inconsistent behaviour in `LC_RNG` across platforms as the line 

```
long test = a*lo - r*hi;
```

Will overflow under different conditions. This PR uses a fixed size variable for the type `test`. Note that this will cause the behaviour of `LC_RNG` to change on 64 bit Windows platforms.