### PR TITLE
Fix RDSEED hang on x86 (GH #872)

### DIFF
--- a/cryptest.nmake
+++ b/cryptest.nmake
@@ -118,7 +118,7 @@ LIB_OBJS = \
     zdeflate.obj zinflate.obj zlib.obj
 
 ASM_OBJS = \
-    rdrand-x86.obj rdrand-x64.obj x64masm.obj x64dll.obj
+    rdrand-x86.obj rdrand-x64.obj rdseed-x86.obj rdseed-x64.obj x64masm.obj x64dll.obj
 
 TEST_SRCS = \
     test.cpp bench1.cpp bench2.cpp bench3.cpp datatest.cpp \
@@ -196,10 +196,12 @@ PLATFORM = x64
 # CXXFLAGS = $(CXXFLAGS) /DWINAPI_FAMILY=WINAPI_FAMILY_APP
 AS = ml.exe
 ASFLAGS = /nologo /D_M_X86 /W3 /Cx /Zi /safeseh
-LIB_SRCS = $(LIB_SRCS) rdrand.cpp rdrand.asm
-LIB_OBJS = $(LIB_OBJS) rdrand-x86.obj
+LIB_SRCS = $(LIB_SRCS) rdrand.cpp rdrand.asm rdseed.asm
+LIB_OBJS = $(LIB_OBJS) rdrand-x86.obj rdseed-x86.obj
 LDFLAGS = $(LDFLAGS) /MACHINE:X86
 LDLIBS = $(LDLIBS) kernel32.lib
+RDRAND_OBJ = rdrand-x86.obj
+RDSEED_OBJ = rdseed-x86.obj
 !ENDIF
 
 # May need $(VCINSTALLDIR)\bin\amd64\ml64.exe
@@ -209,10 +211,12 @@ LDLIBS = $(LDLIBS) kernel32.lib
 # CXXFLAGS = $(CXXFLAGS) /DWINAPI_FAMILY=WINAPI_FAMILY_APP
 AS = ml64.exe
 ASFLAGS = /nologo /D_M_X64 /W3 /Cx /Zi
-LIB_SRCS = $(LIB_SRCS) rdrand.cpp rdrand.asm
-LIB_OBJS = $(LIB_OBJS) rdrand-x64.obj x64masm.obj x64dll.obj
+LIB_SRCS = $(LIB_SRCS) rdrand.cpp rdrand.asm rdseed.asm
+LIB_OBJS = $(LIB_OBJS) rdrand-x64.obj rdseed-x64.obj x64masm.obj x64dll.obj
 LDFLAGS = $(LDFLAGS) /MACHINE:X64
 LDLIBS = $(LDLIBS) kernel32.lib
+RDRAND_OBJ = rdrand-x64.obj
+RDSEED_OBJ = rdseed-x64.obj
 !ENDIF
 
 !IF "$(PLATFORM)" == "ARM" || "$(PLATFORM)" == "arm" || "$(PLATFORM)" == "ARM64" || "$(PLATFORM)" == "arm64"
@@ -283,21 +287,27 @@ pch.pch: pch.h pch.cpp
 	$(CXX) $(CXXFLAGS) /Yc"pch.h" /Fp"pch.pch" /c pch.cpp
 
 # No precompiled headers
-iterhash.obj:
+iterhash.obj: iterhash.h iterhash.cpp
 	$(CXX) $(CXXFLAGS) /Y- /c iterhash.cpp
-dll.obj:
+dll.obj: dll.h dll.cpp
 	$(CXX) $(CXXFLAGS) /Y- /c dll.cpp
-rdrand.obj:
+rdrand.obj: rdrand.cpp $(RDRAND_OBJ)
 	$(CXX) $(CXXFLAGS) /c rdrand.cpp
+rdseed.obj: rdseed.cpp $(RDSEED_OBJ)
+	$(CXX) $(CXXFLAGS) /c rdseed.cpp
 
 # Built for x86/x64
-rdrand-x86.obj:
+rdrand-x86.obj: rdrand.asm
 	$(AS) $(ASFLAGS) /Fo rdrand-x86.obj /c rdrand.asm
-rdrand-x64.obj:
+rdrand-x64.obj: rdrand.asm
 	$(AS) $(ASFLAGS) /Fo rdrand-x64.obj /c rdrand.asm
-x64masm.obj:
+rdseed-x86.obj: rdseed.asm
+	$(AS) $(ASFLAGS) /Fo rdseed-x86.obj /c rdseed.asm
+rdseed-x64.obj: rdseed.asm
+	$(AS) $(ASFLAGS) /Fo rdseed-x64.obj /c rdseed.asm
+x64masm.obj: x64masm.asm
 	$(AS) $(ASFLAGS) /Fo x64masm.obj /c x64masm.asm
-x64dll.obj:
+x64dll.obj: x64dll.asm
 	$(AS) $(ASFLAGS) /Fo x64dll.obj /c x64dll.asm
 
 # You may need to delete this on early versions of Visual Studio.

--- a/cryptest.nmake
+++ b/cryptest.nmake
@@ -291,10 +291,8 @@ iterhash.obj: iterhash.h iterhash.cpp
 	$(CXX) $(CXXFLAGS) /Y- /c iterhash.cpp
 dll.obj: dll.h dll.cpp
 	$(CXX) $(CXXFLAGS) /Y- /c dll.cpp
-rdrand.obj: rdrand.cpp $(RDRAND_OBJ)
+rdrand.obj: rdrand.h rdrand.cpp
 	$(CXX) $(CXXFLAGS) /c rdrand.cpp
-rdseed.obj: rdseed.cpp $(RDSEED_OBJ)
-	$(CXX) $(CXXFLAGS) /c rdseed.cpp
 
 # Built for x86/x64
 rdrand-x86.obj: rdrand.asm

--- a/cryptlib.vcxproj
+++ b/cryptlib.vcxproj
@@ -373,6 +373,16 @@
       <Command>ml64.exe /c /nologo /D_M_X64 /W3 /Cx /Zi /Fo"$(IntDir)rdrand-x64.obj" "%(FullPath)"</Command>
       <Outputs>$(IntDir)\rdrand-x64.obj;%(Outputs)</Outputs>
     </CustomBuild>
+    <CustomBuild Condition="'$(Platform)'=='Win32'" Include="rdseed.asm">
+      <Message>Building and assembling rdseed.asm</Message>
+      <Command>ml.exe /c /nologo /D_M_X86 /W3 /Cx /Zi /safeseh /Fo"$(IntDir)rdseed-x86.obj" "%(FullPath)"</Command>
+      <Outputs>$(IntDir)\rdseed-x86.obj;%(Outputs)</Outputs>
+    </CustomBuild>
+    <CustomBuild Condition="'$(Platform)'=='x64'" Include="rdseed.asm">
+      <Message>Building and assembling rdseed.asm</Message>
+      <Command>ml64.exe /c /nologo /D_M_X64 /W3 /Cx /Zi /Fo"$(IntDir)rdseed-x64.obj" "%(FullPath)"</Command>
+      <Outputs>$(IntDir)\rdseed-x64.obj;%(Outputs)</Outputs>
+    </CustomBuild>
     <CustomBuild Condition="'$(Platform)'=='x64' AND ('$(Configuration)'=='Debug' Or '$(Configuration)'=='Release')" Include="x64dll.asm">
       <Message>Building and assembling x64dll.asm</Message>
       <Command>ml64.exe /c /nologo /D_M_X64 /W3 /Zi /Fo"$(IntDir)x64dll.obj" "%(FullPath)"</Command>

--- a/cryptlib.vcxproj.filters
+++ b/cryptlib.vcxproj.filters
@@ -1064,6 +1064,9 @@
     <CustomBuild Include="rdrand.asm">
       <Filter>Source Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="rdseed.asm">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
     <CustomBuild Include="x64dll.asm">
       <Filter>Source Files</Filter>
     </CustomBuild>

--- a/rdseed.asm
+++ b/rdseed.asm
@@ -1,7 +1,7 @@
 ;; rdrand.asm - written and placed in public domain by Jeffrey Walton and Uri Blumenthal.
 ;;              Copyright assigned to the Crypto++ project.
 
-;; This ASM file provides RDRAND to downlevel Microsoft tool chains.
+;; This ASM file provides RDSEED to downlevel Microsoft tool chains.
 ;; Everything "just works" under Visual Studio. Other platforms will
 ;; have to run MASM/MASM-64 and then link to the object files.
 
@@ -13,19 +13,19 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-TITLE    MASM_RDRAND_GenerateBlock source file
-SUBTITLE Microsoft specific ASM code to utilize RDRAND for down level Microsoft toolchains
+TITLE    MASM_RDSEED_GenerateBlock source file
+SUBTITLE Microsoft specific ASM code to utilize RDSEED for down level Microsoft toolchains
 
-PUBLIC MASM_RDRAND_GenerateBlock
+PUBLIC MASM_RDSEED_GenerateBlock
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; C/C++ Function prototypes (both are fastcall)
 ;;   X86:
-;;      extern "C" void __fastcall MASM_RDRAND_GenerateBlock(byte* ptr, size_t size);
+;;      extern "C" void __fastcall MASM_RDSEED_GenerateBlock(byte* ptr, size_t size);
 ;;   X64:
-;;      extern "C" void __fastcall MASM_RDRAND_GenerateBlock(byte* ptr, size_t size);
+;;      extern "C" void __fastcall MASM_RDSEED_GenerateBlock(byte* ptr, size_t size);
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -36,7 +36,7 @@ IFDEF _M_X86    ;; Set via the command line
 .MODEL FLAT
 
 ;; Fastcall calling conventions exports
-ALIAS <@MASM_RDRAND_GenerateBlock@8> = <MASM_RDRAND_GenerateBlock>
+ALIAS <@MASM_RDSEED_GenerateBlock@8> = <MASM_RDSEED_GenerateBlock>
 
 ENDIF
 
@@ -54,74 +54,74 @@ OPTION EPILOGUE:NONE
 ;;   ECX (in): arg1, byte* buffer
 ;;   EDX (in): arg2, size_t bsize
 
-MASM_RDRAND_GenerateBlock PROC   ;; arg1:DWORD, arg2:DWORD
+MASM_RDSEED_GenerateBlock PROC   ;; arg1:DWORD, arg2:DWORD
 
     MWSIZE EQU 04h    ;; machine word size
     buffer EQU ecx
     bsize  EQU edx
 
             ;; Top of While loop
-RDRAND_GenerateBlock_Top:
+RDSEED_GenerateBlock_Top:
 
             ;; Check remaining size
     cmp     bsize, 0
-    je      RDRAND_GenerateBlock_Return
+    je      RDSEED_GenerateBlock_Return
 
-RDRAND_Call_EAX:
-            ;; RDRAND is not available prior to VS2012. Just emit
-            ;;   the byte codes using DB. This is `rdrand eax`.
-    DB      0Fh, 0C7h, 0F0h
+RDSEED_Call_EAX:
+            ;; RDSEED is not available prior to VS2012. Just emit
+            ;;   the byte codes using DB. This is `rdseed eax`.
+    DB      0Fh, 0C7h, 0F8h
 
-            ;; If CF=1, the number returned by RDRAND is valid.
+            ;; If CF=1, the number returned by RDSEED is valid.
             ;; If CF=0, a random number was not available.
 
             ;; Retry immediately
-    jnc     RDRAND_Call_EAX
+    jnc     RDSEED_Call_EAX
 
-RDRAND_succeeded:
+RDSEED_succeeded:
 
     cmp     bsize, MWSIZE
-    jb      RDRAND_Partial_Machine_Word
+    jb      RDSEED_Partial_Machine_Word
 
-RDRAND_Full_Machine_Word:
+RDSEED_Full_Machine_Word:
 
     mov     DWORD PTR [buffer], eax
     add     buffer, MWSIZE        ;; No need for Intel Core 2 slow workarounds, like
     sub     bsize, MWSIZE         ;;   `lea buffer,[buffer+MWSIZE]` for faster adds
 
             ;; Continue
-    jmp     RDRAND_GenerateBlock_Top
+    jmp     RDSEED_GenerateBlock_Top
 
             ;; 1,2,3 bytes remain
-RDRAND_Partial_Machine_Word:
+RDSEED_Partial_Machine_Word:
 
             ;; Test bit 1 to see if size is at least 2
     test    bsize, 2
-    jz      RDRAND_Bit_1_Not_Set
+    jz      RDSEED_Bit_1_Not_Set
 
     mov     WORD PTR [buffer], ax
     shr     eax, 16
     add     buffer, 2
 
-RDRAND_Bit_1_Not_Set:
+RDSEED_Bit_1_Not_Set:
 
             ;; Test bit 0 to see if size is at least 1
     test    bsize, 1
-    jz      RDRAND_Bit_0_Not_Set
+    jz      RDSEED_Bit_0_Not_Set
 
     mov     BYTE PTR [buffer], al
 
-RDRAND_Bit_0_Not_Set:
+RDSEED_Bit_0_Not_Set:
 
             ;; We've hit all the bits
 
-RDRAND_GenerateBlock_Return:
+RDSEED_GenerateBlock_Return:
 
             ;; Clear artifacts
     xor     eax, eax
     ret
 
-MASM_RDRAND_GenerateBlock ENDP
+MASM_RDSEED_GenerateBlock ENDP
 
 ;; OPTION PROLOGUE:PrologueDef
 ;; OPTION EPILOGUE:EpilogueDef
@@ -142,84 +142,84 @@ OPTION EPILOGUE:NONE
 ;;   RCX (in): arg1, byte* buffer
 ;;   RDX (in): arg2, size_t bsize
 
-MASM_RDRAND_GenerateBlock PROC   ;; arg1:QWORD, arg2:QWORD
+MASM_RDSEED_GenerateBlock PROC   ;; arg1:QWORD, arg2:QWORD
 
     MWSIZE EQU 08h    ;; machine word size
     buffer EQU rcx
     bsize  EQU rdx
 
             ;; Top of While loop
-RDRAND_GenerateBlock_Top:
+RDSEED_GenerateBlock_Top:
 
             ;; Check remaining size
     cmp     bsize, 0
-    je      RDRAND_GenerateBlock_Return
+    je      RDSEED_GenerateBlock_Return
 
-RDRAND_Call_RAX:
-            ;; RDRAND is not available prior to VS2012. Just emit
-            ;;   the byte codes using DB. This is `rdrand rax`.
-    DB      048h, 0Fh, 0C7h, 0F0h
+RDSEED_Call_RAX:
+            ;; RDSEED is not available prior to VS2012. Just emit
+            ;;   the byte codes using DB. This is `rdseed rax`.
+    DB      048h, 0Fh, 0C7h, 0F8h
 
-            ;; If CF=1, the number returned by RDRAND is valid.
+            ;; If CF=1, the number returned by RDSEED is valid.
             ;; If CF=0, a random number was not available.
 
             ;; Retry immediately
-    jnc     RDRAND_Call_RAX
+    jnc     RDSEED_Call_RAX
 
-RDRAND_succeeded:
+RDSEED_succeeded:
 
     cmp     bsize, MWSIZE
-    jb      RDRAND_Partial_Machine_Word
+    jb      RDSEED_Partial_Machine_Word
 
-RDRAND_Full_Machine_Word:
+RDSEED_Full_Machine_Word:
 
     mov     QWORD PTR [buffer], rax
     add     buffer, MWSIZE
     sub     bsize, MWSIZE
 
             ;; Continue
-    jmp     RDRAND_GenerateBlock_Top
+    jmp     RDSEED_GenerateBlock_Top
 
             ;; 1,2,3,4,5,6,7 bytes remain
-RDRAND_Partial_Machine_Word:
+RDSEED_Partial_Machine_Word:
 
             ;; Test bit 2 to see if size is at least 4
     test    bsize, 4
-    jz      RDRAND_Bit_2_Not_Set
+    jz      RDSEED_Bit_2_Not_Set
 
     mov     DWORD PTR [buffer], eax
     shr     rax, 32
     add     buffer, 4
 
-RDRAND_Bit_2_Not_Set:
+RDSEED_Bit_2_Not_Set:
 
             ;; Test bit 1 to see if size is at least 2
     test    bsize, 2
-    jz      RDRAND_Bit_1_Not_Set
+    jz      RDSEED_Bit_1_Not_Set
 
     mov     WORD PTR [buffer], ax
     shr     eax, 16
     add     buffer, 2
 
-RDRAND_Bit_1_Not_Set:
+RDSEED_Bit_1_Not_Set:
 
             ;; Test bit 0 to see if size is at least 1
     test    bsize, 1
-    jz      RDRAND_Bit_0_Not_Set
+    jz      RDSEED_Bit_0_Not_Set
 
     mov     BYTE PTR [buffer], al
 
-RDRAND_Bit_0_Not_Set:
+RDSEED_Bit_0_Not_Set:
 
             ;; We've hit all the bits
 
-RDRAND_GenerateBlock_Return:
+RDSEED_GenerateBlock_Return:
 
             ;; Clear artifacts
     xor     rax, rax
     ret
 
-MASM_RDRAND_GenerateBlock ENDP
+MASM_RDSEED_GenerateBlock ENDP
 
 ;; OPTION PROLOGUE:PrologueDef
 ;; OPTION EPILOGUE:EpilogueDef

--- a/test.cpp
+++ b/test.cpp
@@ -176,9 +176,8 @@ int scoped_main(int argc, char *argv[])
 		// A hint to help locate TestData/ and TestVectors/ after install.
 		SetArgvPathHint(argv[0], g_argvPathHint);
 
-		// Set a seed for reproducible results. It can be set on the command line.
-		// If the seed is short then it is padded with spaces. If the seed is
-		// missing then time() is used.
+		// Set a seed for reproducible results. If the seed is too short then
+		// it is padded with spaces. If the seed is missing then time() is used.
 		// For example:
 		//   ./cryptest.exe v seed=abcdefg
 		SetGlobalSeed(argc, argv, s_globalSeed);


### PR DESCRIPTION
Calls to `MASM_RDSEED_GenerateBlock` would hang for an unknown reasons on Windows 10 and VS2017/VS2019 toolchains. Similar calls to `MASM_RDRAND_GenerateBlock` worked as expected. They were effectively the same code. The only differences were the function names and the opcodes (they were literally copy/paste).

Splitting `rdrand.asm` (with both `RDRAND` and `RDSEED`) into `rdrand.asm` (with `RDRAND`) and `rdseed.asm` (with `RDSEED`) resolved the issue. We don't know why.