### PR TITLE
config_asm.h: Allow clang-tooling

### DIFF
--- a/config_asm.h
+++ b/config_asm.h
@@ -48,7 +48,7 @@
 // Some relevant bug reports can be found at:
 // * Clang: http://github.com/weidai11/cryptopp/issues/147
 // * Native Client: https://github.com/weidai11/cryptopp/issues/719
-#if (defined(_MSC_VER) && defined(__clang__))
+#if (defined(_MSC_VER) && defined(__clang__) && !(defined( __clang_analyzer__)))
 # error: "Unsupported configuration"
 #endif
 


### PR DESCRIPTION
When using cryptopp in your own projects and using clang tooling (e.g.
clang-tidy) for inspecting your project, this currently errors out due to the #error
directive when done on Windows with MS Visual Studio.

The #error directive here is meant for code execution and not for code
inspection.

So we now don't error out  when __clang_analyzer__ is defined. That
macro was introduced into clang tooling in
https://reviews.llvm.org/D46325.