### PR TITLE
Cleanup config_*.h files, update travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,6 @@ env:
 # specifiying our test cases.
 jobs:
 
-  exclude:
-    - env:
-      BUILD_MODE=""
-
   include:
     - os: linux
       name: Linux with GCC (all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,9 @@ env:
     - ANDROID_NDK_ROOT="$ANDROID_NDK"
 
 matrix:
+
+  exclude:
+
   include:
     - os: linux
       name: Linux with GCC (all)
@@ -491,6 +494,7 @@ script:
 branches:
   only:
     - master
+    - /\/ci$/
 
 addons:
   sonarcloud: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ env:
     - ANDROID_SDK_ROOT="$ANDROID_SDK"
     - ANDROID_NDK_ROOT="$ANDROID_NDK"
 
-matrix:
-
-  exclude:
+# Use jobs rather than matrix since we are precisely
+# specifiying our test cases.
+jobs:
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: cpp
 
+# https://docs.travis-ci.com/user/multi-cpu-architectures
+arch:
+  - amd64
+  - arm64
+
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ os:
   - linux
   - osx
 
-osx_image:
-  - xcode10.1
-
 dist: xenial
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 jobs:
 
   exclude:
-    - env: linux
+    - env:
       BUILD_MODE=""
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ jobs:
 
   exclude:
     - os: linux
-      osx_image: *
+      env:
     - os: osx
-      osx_image: *
+      env:
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,344 +36,393 @@ env:
 matrix:
 
   include:
-  # Linux with GCC (amd64)
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
+      name: Linux with GCC (amd64)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-  # Linux with Clang (amd64)
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
+      name: Linux with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-  # OS X with Clang (amd64)
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=all
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=native
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=no-asm
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=debug
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=asan
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ubsan
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=pem
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=autotools
     - os: osx
+      name: OS X with Clang (amd64)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
-  # Linux with GCC (arm64)
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
+      name: Linux with GCC (arm64)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-  # Linux with Clang (arm64)
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
+      name: Linux with Clang (arm64)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-  # Android on Linux (amd64)
     - os: linux
+      name: Android on Linux (amd64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=armeabi-v7a
     - os: linux
+      name: Android on Linux (amd64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=aarch64
     - os: linux
+      name: Android on Linux (amd64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86
     - os: linux
+      name: Android on Linux (amd64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86_64
-  # iOS on OS X (amd64)
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneOS
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=Arm64
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=AppleTVOS
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneSimulator
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchSimulator
     - os: osx
+      name: iOS on OS X (amd64)
       arch: amd64
       env:
         - BUILD_OS=osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,8 @@ sudo: required
 git:
   depth: 5
 
-# Environment variables
-Env:
-  - BUILD_JOBS=2
-
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
-
 jobs:
   include:
     - os: linux
@@ -26,6 +21,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (native)
       arch: amd64
@@ -33,6 +29,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (no-asm)
       arch: amd64
@@ -40,6 +37,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (debug)
       arch: amd64
@@ -47,6 +45,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (asan)
       arch: amd64
@@ -54,6 +53,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (ubsan)
       arch: amd64
@@ -61,6 +61,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (pem)
       arch: amd64
@@ -68,6 +69,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (autotools)
       arch: amd64
@@ -75,6 +77,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with GCC (cmake)
       arch: amd64
@@ -82,6 +85,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (all)
       arch: amd64
@@ -89,6 +93,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (native)
       arch: amd64
@@ -96,6 +101,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (no-asm)
       arch: amd64
@@ -103,6 +109,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (debug)
       arch: amd64
@@ -110,6 +117,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (asan)
       arch: amd64
@@ -117,6 +125,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (ubsan)
       arch: amd64
@@ -124,6 +133,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (pem)
       arch: amd64
@@ -131,6 +141,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (autotools)
       arch: amd64
@@ -138,6 +149,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
+        - BUILD_JOBS=4
     - os: linux
       name: Linux with Clang (cmake)
       arch: amd64
@@ -145,6 +157,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
+        - BUILD_JOBS=4
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (all)
@@ -153,6 +166,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=all
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (native)
@@ -161,6 +175,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=native
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (no-asm)
@@ -169,6 +184,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (debug)
@@ -177,6 +193,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=debug
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (asan)
@@ -185,6 +202,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=asan
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (ubsan)
@@ -193,6 +211,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ubsan
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (pem)
@@ -201,6 +220,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=pem
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (autotools)
@@ -209,6 +229,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=autotools
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (cmake)
@@ -217,6 +238,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (all)
       arch: arm64
@@ -224,6 +246,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (native)
       arch: arm64
@@ -231,6 +254,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (no-asm)
       arch: arm64
@@ -238,6 +262,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (debug)
       arch: arm64
@@ -245,6 +270,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (asan)
       arch: arm64
@@ -252,6 +278,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (ubsan)
       arch: arm64
@@ -259,6 +286,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (pem)
       arch: arm64
@@ -266,6 +294,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (autotools)
       arch: arm64
@@ -273,6 +302,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (cmake)
       arch: arm64
@@ -280,6 +310,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (all)
       arch: arm64
@@ -287,6 +318,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (native)
       arch: arm64
@@ -294,6 +326,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (no-asm)
       arch: arm64
@@ -301,6 +334,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (debug)
       arch: arm64
@@ -308,6 +342,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (asan)
       arch: arm64
@@ -315,6 +350,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (ubsan)
       arch: arm64
@@ -322,6 +358,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (pem)
       arch: arm64
@@ -329,6 +366,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (autotools)
       arch: arm64
@@ -336,6 +374,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (cmake)
       arch: arm64
@@ -343,12 +382,14 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
+        - BUILD_JOBS=2
     - os: linux
       name: Android on Linux (armeabi-v7a)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
+        - BUILD_JOBS=2
         - PLATFORM=armeabi-v7a
         - ANDROID_HOME="$HOME/android-sdk"
         - ANDROID_SDK="$HOME/android-sdk"
@@ -361,6 +402,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
+        - BUILD_JOBS=2
         - PLATFORM=aarch64
         - ANDROID_HOME="$HOME/android-sdk"
         - ANDROID_SDK="$HOME/android-sdk"
@@ -373,6 +415,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
+        - BUILD_JOBS=2
         - PLATFORM=x86
         - ANDROID_HOME="$HOME/android-sdk"
         - ANDROID_SDK="$HOME/android-sdk"
@@ -385,6 +428,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
+        - BUILD_JOBS=2
         - PLATFORM=x86_64
         - ANDROID_HOME="$HOME/android-sdk"
         - ANDROID_SDK="$HOME/android-sdk"
@@ -398,6 +442,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=iPhoneOS
     - os: osx
       osx_image: xcode10.1
@@ -406,6 +451,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=Arm64
     - os: osx
       osx_image: xcode10.1
@@ -414,6 +460,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=WatchOS
     - os: osx
       osx_image: xcode10.1
@@ -422,6 +469,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=AppleTVOS
     - os: osx
       osx_image: xcode10.1
@@ -430,6 +478,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=iPhoneSimulator
     - os: osx
       osx_image: xcode10.1
@@ -438,6 +487,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=WatchSimulator
     - os: osx
       osx_image: xcode10.1
@@ -446,6 +496,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=AppleTVSimulator
 
   allow_failures:
@@ -455,6 +506,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=WatchOS
     - os: osx
       osx_image: xcode10.1
@@ -462,6 +514,7 @@ jobs:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
+        - BUILD_JOBS=2
         - PLATFORM=iPhoneSimulator
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ sudo: required
 git:
   depth: 5
 
+# Environment variables
+Env:
+  - BUILD_JOBS=2
+  
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
 
@@ -21,7 +25,6 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
-        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (native)
       arch: amd64
@@ -29,7 +32,6 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
-        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (no-asm)
       arch: amd64
@@ -37,7 +39,6 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
-        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (debug)
       arch: amd64
@@ -45,7 +46,6 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
-        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (asan)
       arch: amd64
@@ -53,7 +53,6 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
-        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (ubsan)
       arch: amd64
@@ -508,7 +507,7 @@ script:
         ./cryptest.exe tv all
     fi
 
-# whitelist branches to avoid testing feature branches twice
+# Whitelist branches to avoid testing feature branches twice
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
 # See https://docs.travis-ci.com/user/reference/overview/ and
 # https://docs.travis-ci.com/user/multi-cpu-architectures
+# https://docs.travis-ci.com/user/multi-cpu-architectures
 
 language: cpp
-
-# https://docs.travis-ci.com/user/multi-cpu-architectures
-arch:
-  - amd64
-  - arm64
-
-os:
-  - linux
-  - osx
-
 dist: xenial
 sudo: required
 
 git:
   depth: 5
-
-compiler:
-  - clang
-  - gcc
 
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # See https://docs.travis-ci.com/user/reference/overview/ and
 # https://docs.travis-ci.com/user/multi-cpu-architectures
 # https://docs.travis-ci.com/user/multi-cpu-architectures
+# https://github.com/travis-ci/travis-yml/blob/master/schema.json
 
 language: cpp
 dist: xenial
@@ -12,7 +13,7 @@ git:
 # Environment variables
 Env:
   - BUILD_JOBS=2
-  
+
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,12 @@ env:
 # specifiying our test cases.
 jobs:
 
+  exclude:
+    - os: linux
+      osx_image: *
+    - os: osx
+      osx_image: *
+
   include:
     - os: linux
       name: Linux with GCC (all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# See https://docs.travis-ci.com/user/reference/overview/ and
+# https://docs.travis-ci.com/user/multi-cpu-architectures
+
 language: cpp
 
 # https://docs.travis-ci.com/user/multi-cpu-architectures
@@ -32,8 +35,8 @@ env:
 
 matrix:
 
+  # Linux with GCC (amd64)
   include:
-    # Linux with GCC (amd64)
     - os: linux
       arch: amd64
       compiler: gcc
@@ -87,8 +90,9 @@ matrix:
       compiler: gcc
       env:
         - BUILD_OS=linux
-        - BUILD_MODE=cmake		
-    # Linux with Clang (amd64)
+        - BUILD_MODE=cmake
+  # Linux with Clang (amd64)
+  include:
     - os: linux
       arch: amd64
       compiler: clang
@@ -143,7 +147,8 @@ matrix:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-    # OS X with Clang (amd64)
+  # OS X with Clang (amd64)
+  include:
     - os: osx
       arch: amd64
       compiler: clang
@@ -198,7 +203,8 @@ matrix:
       env:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
-    # Linux with GCC (arm64)
+  # Linux with GCC (arm64)
+  include:
     - os: linux
       arch: arm64
       compiler: gcc
@@ -252,8 +258,9 @@ matrix:
       compiler: gcc
       env:
         - BUILD_OS=linux
-        - BUILD_MODE=cmake		
-    # Linux with Clang (arm64)
+        - BUILD_MODE=cmake
+  # Linux with Clang (arm64)
+  include:
     - os: linux
       arch: arm64
       compiler: clang
@@ -308,7 +315,8 @@ matrix:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-    # Android on Linux (amd64)
+  # Android on Linux (amd64)
+  include:
     - os: linux
       arch: amd64
       env:
@@ -333,7 +341,8 @@ matrix:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86_64
-    # iOS on OS X (amd64)
+  # iOS on OS X (amd64)
+  include:
     - os: osx
       arch: amd64
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,11 @@ compiler:
   - clang
   - gcc
 
-env:
-  global:
-    - BUILD_JOBS=2
-    - ANDROID_HOME="$HOME/android-sdk"
-    - ANDROID_SDK="$HOME/android-sdk"
-    - ANDROID_NDK="$HOME/android-ndk"
-    - ANDROID_SDK_ROOT="$ANDROID_SDK"
-    - ANDROID_NDK_ROOT="$ANDROID_NDK"
-
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
 
-include:
+jobs:
+  include:
     - os: linux
       name: Linux with GCC (all)
       arch: amd64
@@ -42,6 +34,7 @@ include:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (native)
       arch: amd64
@@ -49,6 +42,7 @@ include:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (no-asm)
       arch: amd64
@@ -56,6 +50,7 @@ include:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (debug)
       arch: amd64
@@ -63,6 +58,7 @@ include:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (asan)
       arch: amd64
@@ -70,6 +66,7 @@ include:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (ubsan)
       arch: amd64
@@ -366,6 +363,11 @@ include:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=armeabi-v7a
+        - ANDROID_HOME="$HOME/android-sdk"
+        - ANDROID_SDK="$HOME/android-sdk"
+        - ANDROID_NDK="$HOME/android-ndk"
+        - ANDROID_SDK_ROOT="$ANDROID_SDK"
+        - ANDROID_NDK_ROOT="$ANDROID_NDK"
     - os: linux
       name: Android on Linux (aarch64)
       arch: amd64
@@ -373,6 +375,11 @@ include:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=aarch64
+        - ANDROID_HOME="$HOME/android-sdk"
+        - ANDROID_SDK="$HOME/android-sdk"
+        - ANDROID_NDK="$HOME/android-ndk"
+        - ANDROID_SDK_ROOT="$ANDROID_SDK"
+        - ANDROID_NDK_ROOT="$ANDROID_NDK"
     - os: linux
       name: Android on Linux (x86)
       arch: amd64
@@ -380,6 +387,11 @@ include:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86
+        - ANDROID_HOME="$HOME/android-sdk"
+        - ANDROID_SDK="$HOME/android-sdk"
+        - ANDROID_NDK="$HOME/android-ndk"
+        - ANDROID_SDK_ROOT="$ANDROID_SDK"
+        - ANDROID_NDK_ROOT="$ANDROID_NDK"
     - os: linux
       name: Android on Linux (x86_64)
       arch: amd64
@@ -387,6 +399,11 @@ include:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86_64
+        - ANDROID_HOME="$HOME/android-sdk"
+        - ANDROID_SDK="$HOME/android-sdk"
+        - ANDROID_NDK="$HOME/android-ndk"
+        - ANDROID_SDK_ROOT="$ANDROID_SDK"
+        - ANDROID_NDK_ROOT="$ANDROID_NDK"
     - os: osx
       osx_image: xcode10.1
       name: iOS on OS X (iPhoneOS)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,8 @@ env:
 jobs:
 
   exclude:
-    - os: linux
-      env:
-    - os: osx
-      env:
+    - env: linux
+      BUILD_MODE=""
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ git:
   depth: 5
 
 # Use jobs rather than matrix since we are precisely
-# specifiying our test cases.
+# specifiying our test cases. Do not move any of the
+# keys (env, os, arch, compiler, etc) into global.
+# Putting them in global invokes the matrix expansion.
 jobs:
   include:
     - os: linux
@@ -21,7 +23,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (native)
       arch: amd64
@@ -29,7 +31,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (no-asm)
       arch: amd64
@@ -37,7 +39,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (debug)
       arch: amd64
@@ -45,7 +47,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (asan)
       arch: amd64
@@ -53,7 +55,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (ubsan)
       arch: amd64
@@ -61,7 +63,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (pem)
       arch: amd64
@@ -69,7 +71,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (autotools)
       arch: amd64
@@ -77,7 +79,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with GCC (cmake)
       arch: amd64
@@ -85,7 +87,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (all)
       arch: amd64
@@ -93,7 +95,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (native)
       arch: amd64
@@ -101,7 +103,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (no-asm)
       arch: amd64
@@ -109,7 +111,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (debug)
       arch: amd64
@@ -117,7 +119,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (asan)
       arch: amd64
@@ -125,7 +127,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (ubsan)
       arch: amd64
@@ -133,7 +135,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (pem)
       arch: amd64
@@ -141,7 +143,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (autotools)
       arch: amd64
@@ -149,7 +151,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: linux
       name: Linux with Clang (cmake)
       arch: amd64
@@ -157,7 +159,7 @@ jobs:
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
-        - BUILD_JOBS=4
+        - BUILD_JOBS=2
     - os: osx
       osx_image: xcode10.1
       name: OS X with Clang (all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ os:
   - linux
   - osx
 
-osx_image:
-  - xcode10.1
-
 dist: xenial
 sudo: required
 
@@ -166,6 +163,7 @@ matrix:
     - os: osx
       name: OS X with Clang (all)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -173,6 +171,7 @@ matrix:
     - os: osx
       name: OS X with Clang (native)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -180,6 +179,7 @@ matrix:
     - os: osx
       name: OS X with Clang (no-asm)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -187,6 +187,7 @@ matrix:
     - os: osx
       name: OS X with Clang (debug)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -194,6 +195,7 @@ matrix:
     - os: osx
       name: OS X with Clang (asan)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -201,6 +203,7 @@ matrix:
     - os: osx
       name: OS X with Clang (ubsan)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -208,6 +211,7 @@ matrix:
     - os: osx
       name: OS X with Clang (pem)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -215,6 +219,7 @@ matrix:
     - os: osx
       name: OS X with Clang (autotools)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -222,6 +227,7 @@ matrix:
     - os: osx
       name: OS X with Clang (cmake)
       arch: amd64
+      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -383,6 +389,7 @@ matrix:
     - os: osx
       name: iOS on OS X (iPhoneOS)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -390,6 +397,7 @@ matrix:
     - os: osx
       name: iOS on OS X (Arm64)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -397,6 +405,7 @@ matrix:
     - os: osx
       name: iOS on OS X (WatchOS)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -404,6 +413,7 @@ matrix:
     - os: osx
       name: iOS on OS X (AppleTVOS)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -411,6 +421,7 @@ matrix:
     - os: osx
       name: iOS on OS X (iPhoneSimulator)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -418,6 +429,7 @@ matrix:
     - os: osx
       name: iOS on OS X (WatchSimulator)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -425,6 +437,7 @@ matrix:
     - os: osx
       name: iOS on OS X (AppleTVSimulator)
       arch: amd64
+      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ compiler:
 env:
   global:
     - BUILD_JOBS=2
+    - BUILD_OS=none
+    - BUILD_MODE=none
     - ANDROID_HOME="$HOME/android-sdk"
     - ANDROID_SDK="$HOME/android-sdk"
     - ANDROID_NDK="$HOME/android-ndk"
@@ -34,6 +36,9 @@ env:
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
 jobs:
+
+  exclude:
+    - os: none
 
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ compiler:
 env:
   global:
     - BUILD_JOBS=2
-    - BUILD_OS=none
-    - BUILD_MODE=none
     - ANDROID_HOME="$HOME/android-sdk"
     - ANDROID_SDK="$HOME/android-sdk"
     - ANDROID_NDK="$HOME/android-ndk"
@@ -35,12 +33,8 @@ env:
 
 # Use jobs rather than matrix since we are precisely
 # specifiying our test cases.
-jobs:
 
-  exclude:
-    - os: none
-
-  include:
+include:
     - os: linux
       name: Linux with GCC (all)
       arch: amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ os:
   - linux
   - osx
 
+osx_image:
+  - xcode10.1
+
 dist: xenial
 sudo: required
-
-osx_image: xcode10.1
 
 git:
   depth: 5
@@ -431,11 +432,13 @@ matrix:
 
   allow_failures:
     - os: osx
+      name: iOS on OS X (WatchOS)
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
+      name: iOS on OS X (iPhoneSimulator)
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ env:
     - ANDROID_NDK_ROOT="$ANDROID_NDK"
 
 matrix:
-
   include:
     - os: linux
       name: Linux with GCC (all)

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,392 +37,392 @@ matrix:
 
   include:
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (all)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (native)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (no-asm)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (debug)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (asan)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (ubsan)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (pem)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (autotools)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
-      name: Linux with GCC (amd64)
+      name: Linux with GCC (cmake)
       arch: amd64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (all)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (native)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (no-asm)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (debug)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (asan)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (ubsan)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (pem)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (autotools)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
-      name: Linux with Clang (amd64)
+      name: Linux with Clang (cmake)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (all)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=all
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (native)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=native
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (no-asm)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=no-asm
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (debug)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=debug
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (asan)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=asan
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (ubsan)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ubsan
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (pem)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=pem
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (autotools)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=autotools
     - os: osx
-      name: OS X with Clang (amd64)
+      name: OS X with Clang (cmake)
       arch: amd64
       compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (all)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (native)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (no-asm)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (debug)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (asan)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (ubsan)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (pem)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (autotools)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
-      name: Linux with GCC (arm64)
+      name: Linux with GCC (cmake)
       arch: arm64
       compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (all)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=all
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (native)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=native
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (no-asm)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=no-asm
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (debug)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (asan)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=asan
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (ubsan)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=ubsan
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (pem)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (autotools)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
-      name: Linux with Clang (arm64)
+      name: Linux with Clang (cmake)
       arch: arm64
       compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
     - os: linux
-      name: Android on Linux (amd64)
+      name: Android on Linux (armeabi-v7a)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=armeabi-v7a
     - os: linux
-      name: Android on Linux (amd64)
+      name: Android on Linux (aarch64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=aarch64
     - os: linux
-      name: Android on Linux (amd64)
+      name: Android on Linux (x86)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86
     - os: linux
-      name: Android on Linux (amd64)
+      name: Android on Linux (x86_64)
       arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86_64
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (iPhoneOS)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneOS
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (Arm64)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=Arm64
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (WatchOS)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (AppleTVOS)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=AppleTVOS
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (iPhoneSimulator)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneSimulator
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (WatchSimulator)
       arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchSimulator
     - os: osx
-      name: iOS on OS X (amd64)
+      name: iOS on OS X (AppleTVSimulator)
       arch: amd64
       env:
         - BUILD_OS=osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,98 +30,348 @@ env:
     - ANDROID_SDK_ROOT="$ANDROID_SDK"
     - ANDROID_NDK_ROOT="$ANDROID_NDK"
 
-  matrix:
-    - BUILD_MODE="all"
-    - BUILD_MODE="native"
-    - BUILD_MODE="no-asm"
-    - BUILD_MODE="debug"
-    - BUILD_MODE="asan"
-    - BUILD_MODE="ubsan"
-    - BUILD_MODE="pem"
-
 matrix:
 
-  exclude:
-    # Skip GCC on OS X entirely
-    - os: osx
-      compiler: gcc
-
   include:
+    # Linux with GCC (amd64)
     - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=native
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=no-asm
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=asan
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=ubsan
+    - os: linux
+      arch: amd64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=pem
+    - os: linux
+      arch: amd64
+      compiler: gcc
       env:
         - BUILD_OS=linux
         - BUILD_MODE=autotools
     - os: linux
+      arch: amd64
+      compiler: gcc
       env:
         - BUILD_OS=linux
-        - BUILD_MODE=cmake
+        - BUILD_MODE=cmake		
+    # Linux with Clang (amd64)
     - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=native
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=no-asm
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=asan
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=ubsan
+    - os: linux
+      arch: amd64
+      compiler: clang
       env:
         - BUILD_OS=linux
         - BUILD_MODE=pem
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=autotools
+    - os: linux
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=cmake
+    # OS X with Clang (amd64)
     - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=all
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=native
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=no-asm
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=debug
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=asan
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=ubsan
+    - os: osx
+      arch: amd64
+      compiler: clang
+      env:
+        - BUILD_OS=osx
+        - BUILD_MODE=pem
+    - os: osx
+      arch: amd64
+      compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=autotools
     - os: osx
+      arch: amd64
+      compiler: clang
       env:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
-    - os: osx
+    # Linux with GCC (arm64)
+    - os: linux
+      arch: arm64
+      compiler: gcc
       env:
-        - BUILD_OS=osx
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=native
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=no-asm
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=asan
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=ubsan
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
         - BUILD_MODE=pem
     - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=autotools
+    - os: linux
+      arch: arm64
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=cmake		
+    # Linux with Clang (arm64)
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=native
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=no-asm
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=asan
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=ubsan
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=pem
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=autotools
+    - os: linux
+      arch: arm64
+      compiler: clang
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=cmake
+    # Android on Linux (amd64)
+    - os: linux
+      arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=armeabi-v7a
     - os: linux
+      arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=aarch64
     - os: linux
+      arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86
     - os: linux
+      arch: amd64
       env:
         - BUILD_OS=linux
         - BUILD_MODE=android
         - PLATFORM=x86_64
+    # iOS on OS X (amd64)
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneOS
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=Arm64
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=AppleTVOS
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=iPhoneSimulator
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchSimulator
     - os: osx
+      arch: amd64
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ env:
 
 matrix:
 
-  # Linux with GCC (amd64)
   include:
+  # Linux with GCC (amd64)
     - os: linux
       arch: amd64
       compiler: gcc
@@ -92,7 +92,6 @@ matrix:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
   # Linux with Clang (amd64)
-  include:
     - os: linux
       arch: amd64
       compiler: clang
@@ -148,7 +147,6 @@ matrix:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
   # OS X with Clang (amd64)
-  include:
     - os: osx
       arch: amd64
       compiler: clang
@@ -204,7 +202,6 @@ matrix:
         - BUILD_OS=osx
         - BUILD_MODE=cmake
   # Linux with GCC (arm64)
-  include:
     - os: linux
       arch: arm64
       compiler: gcc
@@ -260,7 +257,6 @@ matrix:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
   # Linux with Clang (arm64)
-  include:
     - os: linux
       arch: arm64
       compiler: clang
@@ -316,7 +312,6 @@ matrix:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
   # Android on Linux (amd64)
-  include:
     - os: linux
       arch: amd64
       env:
@@ -342,7 +337,6 @@ matrix:
         - BUILD_MODE=android
         - PLATFORM=x86_64
   # iOS on OS X (amd64)
-  include:
     - os: osx
       arch: amd64
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ os:
   - linux
   - osx
 
+osx_image:
+  - xcode10.1
+
 dist: xenial
 sudo: required
 
@@ -163,7 +166,6 @@ matrix:
     - os: osx
       name: OS X with Clang (all)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -171,7 +173,6 @@ matrix:
     - os: osx
       name: OS X with Clang (native)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -179,7 +180,6 @@ matrix:
     - os: osx
       name: OS X with Clang (no-asm)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -187,7 +187,6 @@ matrix:
     - os: osx
       name: OS X with Clang (debug)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -195,7 +194,6 @@ matrix:
     - os: osx
       name: OS X with Clang (asan)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -203,7 +201,6 @@ matrix:
     - os: osx
       name: OS X with Clang (ubsan)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -211,7 +208,6 @@ matrix:
     - os: osx
       name: OS X with Clang (pem)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -219,7 +215,6 @@ matrix:
     - os: osx
       name: OS X with Clang (autotools)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -227,7 +222,6 @@ matrix:
     - os: osx
       name: OS X with Clang (cmake)
       arch: amd64
-      osx_image: xcode10.1
       compiler: clang
       env:
         - BUILD_OS=osx
@@ -389,7 +383,6 @@ matrix:
     - os: osx
       name: iOS on OS X (iPhoneOS)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -397,7 +390,6 @@ matrix:
     - os: osx
       name: iOS on OS X (Arm64)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -405,7 +397,6 @@ matrix:
     - os: osx
       name: iOS on OS X (WatchOS)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -413,7 +404,6 @@ matrix:
     - os: osx
       name: iOS on OS X (AppleTVOS)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -421,7 +411,6 @@ matrix:
     - os: osx
       name: iOS on OS X (iPhoneSimulator)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -429,7 +418,6 @@ matrix:
     - os: osx
       name: iOS on OS X (WatchSimulator)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
@@ -437,7 +425,6 @@ matrix:
     - os: osx
       name: iOS on OS X (AppleTVSimulator)
       arch: amd64
-      osx_image: xcode10.1
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,7 @@ jobs:
         - BUILD_OS=linux
         - BUILD_MODE=cmake
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (all)
       arch: amd64
       compiler: clang
@@ -177,6 +178,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=all
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (native)
       arch: amd64
       compiler: clang
@@ -184,6 +186,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=native
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (no-asm)
       arch: amd64
       compiler: clang
@@ -191,6 +194,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=no-asm
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (debug)
       arch: amd64
       compiler: clang
@@ -198,6 +202,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=debug
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (asan)
       arch: amd64
       compiler: clang
@@ -205,6 +210,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=asan
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (ubsan)
       arch: amd64
       compiler: clang
@@ -212,6 +218,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=ubsan
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (pem)
       arch: amd64
       compiler: clang
@@ -219,6 +226,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=pem
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (autotools)
       arch: amd64
       compiler: clang
@@ -226,6 +234,7 @@ jobs:
         - BUILD_OS=osx
         - BUILD_MODE=autotools
     - os: osx
+      osx_image: xcode10.1
       name: OS X with Clang (cmake)
       arch: amd64
       compiler: clang
@@ -387,6 +396,7 @@ jobs:
         - BUILD_MODE=android
         - PLATFORM=x86_64
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (iPhoneOS)
       arch: amd64
       env:
@@ -394,6 +404,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=iPhoneOS
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (Arm64)
       arch: amd64
       env:
@@ -401,6 +412,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=Arm64
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (WatchOS)
       arch: amd64
       env:
@@ -408,6 +420,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (AppleTVOS)
       arch: amd64
       env:
@@ -415,6 +428,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=AppleTVOS
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (iPhoneSimulator)
       arch: amd64
       env:
@@ -422,6 +436,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=iPhoneSimulator
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (WatchSimulator)
       arch: amd64
       env:
@@ -429,6 +444,7 @@ jobs:
         - BUILD_MODE=ios
         - PLATFORM=WatchSimulator
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (AppleTVSimulator)
       arch: amd64
       env:
@@ -438,12 +454,14 @@ jobs:
 
   allow_failures:
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (WatchOS)
       env:
         - BUILD_OS=osx
         - BUILD_MODE=ios
         - PLATFORM=WatchOS
     - os: osx
+      osx_image: xcode10.1
       name: iOS on OS X (iPhoneSimulator)
       env:
         - BUILD_OS=osx

--- a/config_asm.h
+++ b/config_asm.h
@@ -28,7 +28,8 @@
 // #define CRYPTOPP_DISABLE_ASM 1
 
 // https://github.com/weidai11/cryptopp/issues/719
-#if defined(__native_client__) && !defined(CRYPTOPP_DISABLE_ASM)
+#if defined(__native_client__)
+# undef CRYPTOPP_DISABLE_ASM
 # define CRYPTOPP_DISABLE_ASM 1
 #endif
 
@@ -38,49 +39,34 @@
 // Also see https://bugs.llvm.org/show_bug.cgi?id=39895 .
 // #define CRYPTOPP_DISABLE_MIXED_ASM 1
 
-#ifndef CRYPTOPP_DISABLE_MIXED_ASM
-# if defined(__clang__)
-#  define CRYPTOPP_DISABLE_MIXED_ASM 1
-# endif
+#if defined(__clang__)
+# undef CRYPTOPP_DISABLE_MIXED_ASM
+# define CRYPTOPP_DISABLE_MIXED_ASM 1
 #endif
 
 // CRYPTOPP_ALLOW_UNALIGNED_DATA_ACCESS is no longer honored. It
 // was removed at https://github.com/weidai11/cryptopp/issues/682
 // #define CRYPTOPP_ALLOW_UNALIGNED_DATA_ACCESS 1
 
-// It is OK to remove the hard stop below, but you are on your own.
-// After building the library be sure to run self tests described
-// https://www.cryptopp.com/wiki/Release_Process#Self_Tests
-// Some relevant bug reports can be found at:
-// * Clang: http://github.com/weidai11/cryptopp/issues/147
-// * Native Client: https://github.com/weidai11/cryptopp/issues/719
-#if (defined(_MSC_VER) && defined(__clang__) && !(defined( __clang_analyzer__)))
-# error: "Unsupported configuration"
-#endif
-
-// You may need to force include a C++ header on Android when using STLPort to ensure
-// _STLPORT_VERSION is defined: CXXFLAGS="-DNDEBUG -g2 -O2 -std=c++11 -include iosfwd"
-// TODO: Figure out C++17 and lack of std::uncaught_exception
-#if (defined(_MSC_VER) && _MSC_VER <= 1300) || defined(__MWERKS__) || (defined(_STLPORT_VERSION) && ((_STLPORT_VERSION < 0x450) || defined(_STLP_NO_UNCAUGHT_EXCEPT_SUPPORT)))
-#define CRYPTOPP_DISABLE_UNCAUGHT_EXCEPTION
-#endif
-
 // ***************** IA32 CPU features ********************
 
 #if (CRYPTOPP_BOOL_X86 || CRYPTOPP_BOOL_X32 || CRYPTOPP_BOOL_X64)
 
 // Apple Clang prior to 5.0 cannot handle SSE2
-#if !defined(CRYPTOPP_DISABLE_ASM) && defined(CRYPTOPP_APPLE_CLANG_VERSION) && (CRYPTOPP_APPLE_CLANG_VERSION < 50000)
+#if defined(CRYPTOPP_APPLE_CLANG_VERSION) && (CRYPTOPP_APPLE_CLANG_VERSION < 50000)
 # define CRYPTOPP_DISABLE_ASM 1
 #endif
 
 // Sun Studio 12.1 provides GCC inline assembly
 // http://blogs.oracle.com/x86be/entry/gcc_style_asm_inlining_support
-#if !defined(CRYPTOPP_DISABLE_ASM) && defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5100)
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5100)
 # define CRYPTOPP_DISABLE_ASM 1
 #endif
 
-#if !defined(CRYPTOPP_DISABLE_ASM) && ((defined(_MSC_VER) && defined(_M_IX86)) || (defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))))
+// Guard everything in CRYPTOPP_DISABLE_ASM
+#if !defined(CRYPTOPP_DISABLE_ASM)
+
+#if (defined(_MSC_VER) && defined(_M_IX86)) || ((defined(__GNUC__) && (defined(__i386__)) || defined(__x86_64__)))
 	// C++Builder 2010 does not allow "call label" where label is defined within inline assembly
 	#define CRYPTOPP_X86_ASM_AVAILABLE 1
 
@@ -93,20 +79,20 @@
 	#endif
 #endif
 
-#if !defined(CRYPTOPP_DISABLE_ASM) && defined(_MSC_VER) && defined(_M_X64)
+#if defined(_MSC_VER) && defined(_M_X64)
 	#define CRYPTOPP_X64_MASM_AVAILABLE 1
 #endif
 
-#if !defined(CRYPTOPP_DISABLE_ASM) && defined(__GNUC__) && defined(__x86_64__)
+#if defined(__GNUC__) && defined(__x86_64__)
 	#define CRYPTOPP_X64_ASM_AVAILABLE 1
 #endif
 
 // 32-bit SunCC does not enable SSE2 by default.
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_SSE2) && (defined(_MSC_VER) || CRYPTOPP_GCC_VERSION >= 30300 || defined(__SSE2__) || (__SUNPRO_CC >= 0x5100))
+#if !defined(CRYPTOPP_DISABLE_SSE2) && (defined(_MSC_VER) || CRYPTOPP_GCC_VERSION >= 30300 || defined(__SSE2__) || (__SUNPRO_CC >= 0x5100))
 	#define CRYPTOPP_SSE2_INTRIN_AVAILABLE 1
 #endif
 
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_SSSE3)
+#if !defined(CRYPTOPP_DISABLE_SSSE3)
 # if defined(__SSSE3__) || (_MSC_VER >= 1500) || \
 	(CRYPTOPP_GCC_VERSION >= 40300) || (__INTEL_COMPILER >= 1000) || (__SUNPRO_CC >= 0x5110) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 20300) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40000)
@@ -138,7 +124,7 @@
 #endif
 
 // Requires Sun Studio 12.3 (SunCC 0x5120) in theory.
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_CLMUL) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
+#if !defined(CRYPTOPP_DISABLE_CLMUL) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
 	(defined(__PCLMUL__) || (_MSC_FULL_VER >= 150030729) || (__SUNPRO_CC >= 0x5120) || \
 	(CRYPTOPP_GCC_VERSION >= 40300) || (__INTEL_COMPILER >= 1110) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 30200) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300))
@@ -146,7 +132,7 @@
 #endif
 
 // Requires Sun Studio 12.3 (SunCC 0x5120)
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_AESNI) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
+#if !defined(CRYPTOPP_DISABLE_AESNI) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
 	(defined(__AES__) || (_MSC_FULL_VER >= 150030729) || (__SUNPRO_CC >= 0x5120) || \
 	(CRYPTOPP_GCC_VERSION >= 40300) || (__INTEL_COMPILER >= 1110) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 30200) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300))
@@ -171,7 +157,7 @@
 
 // Guessing at SHA for SunCC. Its not in Sun Studio 12.6. Also see
 // http://stackoverflow.com/questions/45872180/which-xarch-for-sha-extensions-on-solaris
-#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_SHANI) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
+#if !defined(CRYPTOPP_DISABLE_SHANI) && defined(CRYPTOPP_SSE42_AVAILABLE) && \
 	(defined(__SHA__) || (CRYPTOPP_MSC_VERSION >= 1900) || (__SUNPRO_CC >= 0x5160) || \
 	(CRYPTOPP_GCC_VERSION >= 40900) || (__INTEL_COMPILER >= 1300) || \
 	(CRYPTOPP_LLVM_CLANG_VERSION >= 30400) || (CRYPTOPP_APPLE_CLANG_VERSION >= 50100))
@@ -207,7 +193,7 @@
 #endif
 
 // Fixup Android and SSE, Crypto. It may be enabled based on compiler version.
-#if (defined(__ANDROID__) || defined(ANDROID))
+#if defined(__ANDROID__) || defined(ANDROID)
 # if (CRYPTOPP_BOOL_X86)
 #  undef CRYPTOPP_SSE41_AVAILABLE
 #  undef CRYPTOPP_SSE42_AVAILABLE
@@ -237,6 +223,8 @@
 # undef CRYPTOPP_CLMUL_AVAILABLE
 #endif
 
+#endif  // CRYPTOPP_DISABLE_ASM
+
 #endif  // X86, X32, X64
 
 // ***************** ARM CPU features ********************
@@ -249,10 +237,13 @@
 # define CRYPTOPP_DISABLE_ASM 1
 #endif
 
+// Guard everything in CRYPTOPP_DISABLE_ASM
+#if !defined(CRYPTOPP_DISABLE_ASM)
+
 // Requires ACLE 1.0. -mfpu=neon or above must be present
 // Requires GCC 4.3, Clang 2.8 or Visual Studio 2012
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_NEON_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_NEON_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_NEON)
 # if defined(__arm__) || defined(__ARM_NEON) || defined(__ARM_FEATURE_NEON) || defined(_M_ARM)
 #  if (CRYPTOPP_GCC_VERSION >= 40300) || (CRYPTOPP_LLVM_CLANG_VERSION >= 20800) || \
       (CRYPTOPP_MSC_VERSION >= 1700)
@@ -264,7 +255,7 @@
 // ARMv8 and ASIMD. -march=armv8-a or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_ASIMD_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_ASIMD_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_ASIMD)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_NEON) || defined(__ARM_FEATURE_NEON) || defined(__ARM_FEATURE_ASIMD) || \
       (CRYPTOPP_GCC_VERSION >= 40800) || (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || \
@@ -278,7 +269,7 @@
 // ARMv8 and ASIMD. -march=armv8-a+crc or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_CRC32_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_CRC32_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_CRC32)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_CRC32) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_MSC_VERSION >= 1916)
@@ -290,7 +281,7 @@
 // ARMv8 and ASIMD. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_PMULL_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_PMULL_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_PMULL)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_MSC_VERSION >= 1916)
@@ -302,7 +293,7 @@
 // ARMv8 and AES. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_AES_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_AES_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_AES)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_MSC_VERSION >= 1916)
@@ -314,7 +305,7 @@
 // ARMv8 and SHA-1, SHA-256. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_SHA_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_SHA_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SHA)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_MSC_VERSION >= 1916)
@@ -327,7 +318,7 @@
 // ARMv8 and SHA-512, SHA-3. -march=armv8.4-a+crypto or above must be present
 // Requires GCC 8.0, Clang ??? or Visual Studio 20??
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_SHA3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_SHA3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SHA)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_SHA3) || (CRYPTOPP_GCC_VERSION >= 80000)
 #   define CRYPTOPP_ARM_SHA512_AVAILABLE 1
@@ -339,7 +330,7 @@
 // ARMv8 and SM3, SM4. -march=armv8.4-a+crypto or above must be present
 // Requires GCC 8.0, Clang ??? or Visual Studio 20??
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
-#if !defined(CRYPTOPP_ARM_SM3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ASM)
+#if !defined(CRYPTOPP_ARM_SM3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SM3)
 # if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if defined(__ARM_FEATURE_SM3) || (CRYPTOPP_GCC_VERSION >= 80000)
 #   define CRYPTOPP_ARM_SM3_AVAILABLE 1
@@ -372,18 +363,17 @@
 # undef CRYPTOPP_ARM_PMULL_AVAILABLE
 #endif
 
-// Fixup Android and CRC32. It may be enabled based on compiler version.
-#if (defined(__ANDROID__) || defined(ANDROID)) && !defined(__ARM_FEATURE_CRC32)
-# undef CRYPTOPP_ARM_CRC32_AVAILABLE
-#endif
-
-// Fixup Android and Crypto. It may be enabled based on compiler version.
-#if (defined(__ANDROID__) || defined(ANDROID)) && !defined(__ARM_FEATURE_CRYPTO)
+// Disable for Android
+#if defined(__ANDROID__) || defined(ANDROID)
 # undef CRYPTOPP_ARM_CRC32_AVAILABLE
 # undef CRYPTOPP_ARM_PMULL_AVAILABLE
 # undef CRYPTOPP_ARM_AES_AVAILABLE
 # undef CRYPTOPP_ARM_SHA1_AVAILABLE
 # undef CRYPTOPP_ARM_SHA2_AVAILABLE
+# undef CRYPTOPP_ARM_SHA3_AVAILABLE
+# undef CRYPTOPP_ARM_SHA512_AVAILABLE
+# undef CRYPTOPP_ARM_SM3_AVAILABLE
+# undef CRYPTOPP_ARM_SM4_AVAILABLE
 #endif
 
 // Cryptogams offers an ARM asm implementations for AES and SHA. Crypto++ does
@@ -392,7 +382,7 @@
 // than C/C++. Define this to use the Cryptogams AES and SHA implementations
 // on GNU Linux systems. When defined, Crypto++ will use aes_armv4.S,
 // sha1_armv4.S and sha256_armv4.S. https://www.cryptopp.com/wiki/Cryptogams.
-#if !defined(CRYPTOPP_DISABLE_ASM) && defined(__arm__) && defined(__linux__)
+#if defined(__arm__) && defined(__linux__)
 # if defined(__GNUC__) || defined(__clang__)
 #  define CRYPTOGAMS_ARM_AES      1
 #  define CRYPTOGAMS_ARM_SHA1     1
@@ -401,22 +391,16 @@
 # endif
 #endif
 
+#endif  // CRYPTOPP_DISABLE_ASM
+
 #endif  // ARM32, ARM64
 
 // ***************** AltiVec and Power8 ********************
 
 #if (CRYPTOPP_BOOL_PPC32 || CRYPTOPP_BOOL_PPC64)
 
-#if defined(CRYPTOPP_DISABLE_ALTIVEC) || defined(CRYPTOPP_DISABLE_ASM)
-# undef CRYPTOPP_DISABLE_ALTIVEC
-# undef CRYPTOPP_DISABLE_POWER7
-# undef CRYPTOPP_DISABLE_POWER8
-# undef CRYPTOPP_DISABLE_POWER9
-# define CRYPTOPP_DISABLE_ALTIVEC 1
-# define CRYPTOPP_DISABLE_POWER7 1
-# define CRYPTOPP_DISABLE_POWER8 1
-# define CRYPTOPP_DISABLE_POWER9 1
-#endif
+// Guard everything in CRYPTOPP_DISABLE_ASM
+#if !defined(CRYPTOPP_DISABLE_ASM) && !defined(CRYPTOPP_DISABLE_ALTIVEC)
 
 // An old Apple G5 with GCC 4.01 has AltiVec, but its only Power4 or so.
 #if !defined(CRYPTOPP_ALTIVEC_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ALTIVEC)
@@ -460,6 +444,8 @@
 #  define CRYPTOPP_POWER8_SHA_AVAILABLE 1
 # endif
 #endif
+
+#endif  // CRYPTOPP_DISABLE_ASM
 
 #endif  // PPC32, PPC64
 

--- a/config_cxx.h
+++ b/config_cxx.h
@@ -25,6 +25,12 @@
 #include "config_cpu.h"
 #include "config_ver.h"
 
+// You may need to force include a C++ header on Android when using STLPort
+// to ensure _STLPORT_VERSION is defined
+#if (defined(_MSC_VER) && _MSC_VER <= 1300) || defined(__MWERKS__) || (defined(_STLPORT_VERSION) && ((_STLPORT_VERSION < 0x450) || defined(_STLP_NO_UNCAUGHT_EXCEPT_SUPPORT)))
+#define CRYPTOPP_DISABLE_UNCAUGHT_EXCEPTION
+#endif
+
 // Ancient Crypto++ define, dating back to C++98 and C++03.
 #ifndef CRYPTOPP_DISABLE_UNCAUGHT_EXCEPTION
 # define CRYPTOPP_UNCAUGHT_EXCEPTION_AVAILABLE 1

--- a/config_os.h
+++ b/config_os.h
@@ -17,6 +17,15 @@
 
 #include "config_ver.h"
 
+// It is OK to remove the hard stop below, but you are on your own.
+// After building the library be sure to run self tests described
+// https://www.cryptopp.com/wiki/Release_Process#Self_Tests
+// Some relevant bug reports can be found at:
+// * Clang: http://github.com/weidai11/cryptopp/issues/147
+#if (defined(_MSC_VER) && defined(__clang__) && !(defined( __clang_analyzer__)))
+# error: "Unsupported configuration"
+#endif
+
 // Windows platform
 #if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)
 #define CRYPTOPP_WIN32_AVAILABLE


### PR DESCRIPTION
The biggest change in the config files was using `CRYPTOPP_DISABLE_ASM` in `config_asm.h` to guard a block of available defines. Travis was updated to include arm64 testing.