### PR TITLE
Add s390 testing for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -433,24 +433,6 @@ jobs:
         - BUILD_MODE=debug
         - BUILD_JOBS=2
     - os: linux
-      name: Linux with Clang (all)
-      arch: ppc64le
-      compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=all
-        - BUILD_JOBS=2
-    - os: linux
-      name: Linux with Clang (debug)
-      arch: ppc64le
-      compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=debug
-        - BUILD_JOBS=2
-    - os: linux
       name: Linux with GCC (all)
       arch: s390x
       compiler: gcc
@@ -463,24 +445,6 @@ jobs:
       name: Linux with GCC (debug)
       arch: s390x
       compiler: gcc
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=debug
-        - BUILD_JOBS=2
-    - os: linux
-      name: Linux with Clang (all)
-      arch: s390x
-      compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=all
-        - BUILD_JOBS=2
-    - os: linux
-      name: Linux with Clang (debug)
-      arch: s390x
-      compiler: clang
-      dist: bionic
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
@@ -601,7 +565,48 @@ jobs:
         - BUILD_JOBS=2
         - BUILD_ARCH=AppleTVSimulator
 
+  # Clang has a fair amount of trouble
+  # on platforms Apple does not support
   allow_failures:
+    - os: linux
+      name: Linux with Clang (all)
+      arch: s390x
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: s390x
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    # Clang 7.0 and below will likely have trouble due to
+    # https://bugs.llvm.org/show_bug.cgi?id=39704
+    - os: linux
+      name: Linux with Clang (all)
+      arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    # Apple device linker problems
     - os: osx
       osx_image: xcode10.1
       name: iOS on OS X (WatchOS)
@@ -618,18 +623,6 @@ jobs:
         - BUILD_MODE=ios
         - BUILD_JOBS=2
         - BUILD_ARCH=iPhoneSimulator
-    # We should be OK with PPC64 and GCC until Travis disallows
-    # access to the build machines. Clang is a differnt story.
-    # Clang 7.0 and below will likely have trouble due to
-    # https://bugs.llvm.org/show_bug.cgi?id=39704
-    - os: linux
-      name: Linux with GCC (all)
-      arch: ppc64le
-      compiler: gcc
-    - os: linux
-      name: Linux with Clang (all)
-      arch: ppc64le
-      compiler: clang
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -433,6 +433,24 @@ jobs:
         - BUILD_MODE=debug
         - BUILD_JOBS=2
     - os: linux
+      name: Linux with Clang (all)
+      arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    - os: linux
       name: Linux with GCC (all)
       arch: s390x
       compiler: gcc
@@ -445,6 +463,24 @@ jobs:
       name: Linux with GCC (debug)
       arch: s390x
       compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (all)
+      arch: s390x
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: s390x
+      compiler: clang
+      dist: bionic
       env:
         - BUILD_OS=linux
         - BUILD_MODE=debug
@@ -565,64 +601,24 @@ jobs:
         - BUILD_JOBS=2
         - BUILD_ARCH=AppleTVSimulator
 
-  # Clang has a fair amount of trouble
-  # on platforms Apple does not support
   allow_failures:
+    # Clang has a fair amount of trouble
+    # on platforms Apple does not support
     - os: linux
-      name: Linux with Clang (all)
       arch: s390x
       compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=all
-        - BUILD_JOBS=2
-    - os: linux
-      name: Linux with Clang (debug)
-      arch: s390x
-      compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=debug
-        - BUILD_JOBS=2
     # Clang 7.0 and below will likely have trouble due to
     # https://bugs.llvm.org/show_bug.cgi?id=39704
     - os: linux
-      name: Linux with Clang (all)
       arch: ppc64le
       compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=all
-        - BUILD_JOBS=2
-    - os: linux
-      name: Linux with Clang (debug)
-      arch: ppc64le
-      compiler: clang
-      dist: bionic
-      env:
-        - BUILD_OS=linux
-        - BUILD_MODE=debug
-        - BUILD_JOBS=2
     # Apple device linker problems
     - os: osx
       osx_image: xcode10.1
       name: iOS on OS X (WatchOS)
-      env:
-        - BUILD_OS=osx
-        - BUILD_MODE=ios
-        - BUILD_JOBS=2
-        - BUILD_ARCH=WatchOS
     - os: osx
       osx_image: xcode10.1
       name: iOS on OS X (iPhoneSimulator)
-      env:
-        - BUILD_OS=osx
-        - BUILD_MODE=ios
-        - BUILD_JOBS=2
-        - BUILD_ARCH=iPhoneSimulator
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -425,6 +425,14 @@ jobs:
         - BUILD_MODE=all
         - BUILD_JOBS=2
     - os: linux
+      name: Linux with GCC (debug)
+      arch: ppc64le
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    - os: linux
       name: Linux with Clang (all)
       arch: ppc64le
       compiler: clang
@@ -433,11 +441,50 @@ jobs:
         - BUILD_OS=linux
         - BUILD_MODE=all
         - BUILD_JOBS=2
-      addons:
-        apt:
-          packages: ['clang-6.0', 'clang++-6.0']
-          sources: &sources
-            - llvm-toolchain-bionic-6.0
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: ppc64le
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with GCC (all)
+      arch: s390x
+      compiler: gcc
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with GCC (debug)
+      arch: s390x
+      compiler: gcc
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (all)
+      arch: s390x
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=all
+        - BUILD_JOBS=2
+    - os: linux
+      name: Linux with Clang (debug)
+      arch: s390x
+      compiler: clang
+      dist: bionic
+      env:
+        - BUILD_OS=linux
+        - BUILD_MODE=debug
+        - BUILD_JOBS=2
     - os: linux
       name: Android on Linux (armeabi-v7a)
       arch: amd64


### PR DESCRIPTION
Add s390 testing for Travis. Move ppc64 to include jobs. Travis now officially supports both. Also see https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z.