### PR TITLE
Typo in CRYPTO_ASSERT

### DIFF
--- a/tiger.cpp
+++ b/tiger.cpp
@@ -36,7 +36,7 @@ void Tiger::InitState(HashWordType *state)
 
 void Tiger::TruncatedFinal(byte *digest, size_t digestSize)
 {
-	CRYPTOPP_ASSERT(hash != NULLPTR);
+	CRYPTOPP_ASSERT(digest != NULLPTR);
 	ThrowIfInvalidTruncatedSize(digestSize);
 
 	PadLastBlock(56, 0x01);


### PR DESCRIPTION
Compilation error in tiger.cpp due to a CRYPT_ASSERT check of a local variable that doesn't exist.