### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/Install.txt
+++ b/Install.txt
@@ -82,6 +82,19 @@ Crypto++ does not enagage Specter remediations at this time. You can build with 
 
     CXXFLAGS="-DNDEBUG -g2 -O3 -mfunction-return=thunk -mindirect-branch=thunk" make
 
+BUILDING WITH VCPKG
+-------------------
+
+You can download and install cryptopp using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install cryptopp
+
+The cryptopp port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ALTERNATE BUILD SYSTEMS
 -----------------------


### PR DESCRIPTION
Cryptopp is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build cryptopp, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for cryptopp and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.