### PR TITLE
files.cpp Reset file ptr rather than release on init

### DIFF
--- a/files.cpp
+++ b/files.cpp
@@ -23,7 +23,7 @@ void FileStore::StoreInitialize(const NameValuePairs &parameters)
 {
 	m_waiting = false;
 	m_stream = NULLPTR;
-	m_file.release();
+	m_file.reset(nullptr);
 
 	const char *fileName = NULLPTR;
 #if defined(CRYPTOPP_UNIX_AVAILABLE) || _MSC_VER >= 1400
@@ -179,7 +179,7 @@ lword FileStore::Skip(lword skipMax)
 void FileSink::IsolatedInitialize(const NameValuePairs &parameters)
 {
 	m_stream = NULLPTR;
-	m_file.release();
+	m_file.reset(nullptr);
 
 	const char *fileName = NULLPTR;
 #if defined(CRYPTOPP_UNIX_AVAILABLE) || _MSC_VER >= 1400


### PR DESCRIPTION
It looks like there was a possible memleak here or perhaps i'm misunderstanding the function of this class. 

Multiple calls to IsolatedInitialize (public function) would call release on the m_file member which removes the ownership of the underlying ostream from m_file and then that instance is lost and never deleted.

It appears m_file is owned by the FileStore class. On Destruction of FileStore, it will free the resource stored in m_file. File store should also be deleting this memory before it assigns a new instance, no?
