### PR TITLE
Fixed conflicting API names on ARMv7A with OpenSSL

### DIFF
--- a/aes_armv4.S
+++ b/aes_armv4.S
@@ -434,10 +434,10 @@ _armv4_AES_encrypt_block:
 	ldr	pc,[sp],#4		@ pop and return
 .size	_armv4_AES_encrypt_block,.-_armv4_AES_encrypt_block
 
-.globl	AES_set_encrypt_key
-.type	AES_set_encrypt_key,%function
+.globl	AES_set_encrypt_key_ARM
+.type	AES_set_encrypt_key_ARM,%function
 .align	5
-AES_set_encrypt_key:
+AES_set_encrypt_key_ARM:
 _armv4_AES_set_encrypt_key:
 #ifndef	__thumb2__
 	sub	r3,pc,#8		@ AES_set_encrypt_key
@@ -738,12 +738,12 @@ _armv4_AES_set_encrypt_key:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 .word	0xe12fff1e			@ interoperable with Thumb ISA:-)
 #endif
-.size	AES_set_encrypt_key,.-AES_set_encrypt_key
+.size	AES_set_encrypt_key_ARM,.-AES_set_encrypt_key_ARM
 
-.globl	AES_set_decrypt_key
-.type	AES_set_decrypt_key,%function
+.globl	AES_set_decrypt_key_ARM
+.type	AES_set_decrypt_key_ARM,%function
 .align	5
-AES_set_decrypt_key:
+AES_set_decrypt_key_ARM:
 	str	lr,[sp,#-4]!            @ push lr
 	bl	_armv4_AES_set_encrypt_key
 	teq	r0,#0
@@ -753,13 +753,13 @@ AES_set_decrypt_key:
 	mov	r0,r2			@ AES_set_encrypt_key preserves r2,
 	mov	r1,r2			@ which is AES_KEY *key
 	b	_armv4_AES_set_enc2dec_key
-.size	AES_set_decrypt_key,.-AES_set_decrypt_key
+.size	AES_set_decrypt_key_ARM,.-AES_set_decrypt_key_ARM
 
-@ void AES_set_enc2dec_key(const AES_KEY *inp,AES_KEY *out)
-.globl	AES_set_enc2dec_key
-.type	AES_set_enc2dec_key,%function
+@ void AES_set_enc2dec_key_ARM(const AES_KEY *inp,AES_KEY *out)
+.globl	AES_set_enc2dec_key_ARM
+.type	AES_set_enc2dec_key_ARM,%function
 .align	5
-AES_set_enc2dec_key:
+AES_set_enc2dec_key_ARM:
 _armv4_AES_set_enc2dec_key:
 	stmdb	sp!,{r4,r5,r6,r7,r8,r9,r10,r11,r12,lr}
 
@@ -850,7 +850,7 @@ _armv4_AES_set_enc2dec_key:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 .word	0xe12fff1e			@ interoperable with Thumb ISA:-)
 #endif
-.size	AES_set_enc2dec_key,.-AES_set_enc2dec_key
+.size	AES_set_enc2dec_key_ARM,.-AES_set_enc2dec_key_ARM
 
 .type	AES_Td,%object
 .align	5

--- a/aes_armv4.h
+++ b/aes_armv4.h
@@ -18,8 +18,8 @@ extern "C" {
 // Instead of AES_KEY we use a 'word32 rkey[4*15+4]'. It has space for
 // both the AES_MAXNR round keys and the number of rounds in the tail.
 
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits, unsigned int *rkey);
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits, unsigned int *rkey);
+int AES_set_encrypt_key_ARM(const unsigned char *userKey, const int bits, unsigned int *rkey);
+int AES_set_decrypt_key_ARM(const unsigned char *userKey, const int bits, unsigned int *rkey);
 void AES_encrypt_block(const unsigned char *in, unsigned char *out, const unsigned int *rkey);
 void AES_decrypt_block(const unsigned char *in, unsigned char *out, const unsigned int *rkey);
 

--- a/rijndael.cpp
+++ b/rijndael.cpp
@@ -330,8 +330,8 @@ extern size_t Rijndael_Dec_AdvancedProcessBlocks_ARMV8(const word32 *subkeys, si
 #endif
 
 #if (CRYPTOGAMS_ARM_AES)
-extern "C" int AES_set_encrypt_key(const unsigned char *userKey, const int bitLen, word32 *rkey);
-extern "C" int AES_set_decrypt_key(const unsigned char *userKey, const int bitLen, word32 *rkey);
+extern "C" int AES_set_encrypt_key_ARM(const unsigned char *userKey, const int bitLen, word32 *rkey);
+extern "C" int AES_set_decrypt_key_ARM(const unsigned char *userKey, const int bitLen, word32 *rkey);
 extern "C" void AES_encrypt_block(const unsigned char *in, unsigned char *out, const word32 *rkey);
 extern "C" void AES_decrypt_block(const unsigned char *in, unsigned char *out, const word32 *rkey);
 #endif
@@ -349,11 +349,11 @@ extern size_t Rijndael_Dec_AdvancedProcessBlocks128_6x1_ALTIVEC(const word32 *su
 #if (CRYPTOGAMS_ARM_AES)
 int CRYPTOGAMS_set_encrypt_key(const byte *userKey, const int bitLen, word32 *rkey)
 {
-	return AES_set_encrypt_key(userKey, bitLen, rkey);
+	return AES_set_encrypt_key_ARM(userKey, bitLen, rkey);
 }
 int CRYPTOGAMS_set_decrypt_key(const byte *userKey, const int bitLen, word32 *rkey)
 {
-	return AES_set_decrypt_key(userKey, bitLen, rkey);
+	return AES_set_decrypt_key_ARM(userKey, bitLen, rkey);
 }
 void CRYPTOGAMS_encrypt(const byte *inBlock, const byte *xorBlock, byte *outBlock, const word32 *rkey)
 {

--- a/sha.cpp
+++ b/sha.cpp
@@ -67,7 +67,7 @@ extern void SHA256_HashMultipleBlocks_SHANI(word32 *state, const word32 *data, s
 #endif
 
 #if CRYPTOGAMS_ARM_SHA1
-extern "C" void sha1_block_data_order(word32* state, const word32 *data, size_t blocks);
+extern "C" void sha1_block_data_order_ARM(word32* state, const word32 *data, size_t blocks);
 extern "C" void sha1_block_data_order_neon(word32* state, const word32 *data, size_t blocks);
 #endif
 
@@ -308,9 +308,9 @@ void SHA1::Transform(word32 *state, const word32 *data)
 # if defined(CRYPTOPP_LITTLE_ENDIAN)
         word32 dataBuf[16];
         ByteReverse(dataBuf, data, SHA1::BLOCKSIZE);
-        sha1_block_data_order(state, data, 1);
+        sha1_block_data_order_ARM(state, data, 1);
 # else
-        sha1_block_data_order(state, data, 1);
+        sha1_block_data_order_ARM(state, data, 1);
 # endif
         return;
     }
@@ -346,7 +346,7 @@ size_t SHA1::HashMultipleBlocks(const word32 *input, size_t length)
     }
     if (HasARMv7())
     {
-        sha1_block_data_order(m_state, input, length / SHA1::BLOCKSIZE);
+        sha1_block_data_order_ARM(m_state, input, length / SHA1::BLOCKSIZE);
         return length & (SHA1::BLOCKSIZE - 1);
     }
 #endif

--- a/sha1_armv4.S
+++ b/sha1_armv4.S
@@ -79,16 +79,16 @@
 .text
 
 .align	5
-.globl	sha1_block_data_order
-.type	sha1_block_data_order,%function
+.globl	sha1_block_data_order_ARM
+.type	sha1_block_data_order_ARM,%function
 
-sha1_block_data_order:
-.Lsha1_block_data_order:
+sha1_block_data_order_ARM:
+.Lsha1_block_data_order_ARM:
 
 #if __ARM_ARCH__<7 && !defined(__thumb2__)
-	sub	r3,pc,#8		@ sha1_block_data_order
+	sub	r3,pc,#8		@ sha1_block_data_order_ARM
 #else
-	adr	r3,.Lsha1_block_data_order
+	adr	r3,.Lsha1_block_data_order_ARM
 #endif
 
 	stmdb	sp!,{r4,r5,r6,r7,r8,r9,r10,r11,r12,lr}
@@ -542,7 +542,7 @@ sha1_block_data_order:
 	moveq	pc,lr			@ be binary compatible with V4, yet
 .word	0xe12fff1e			@ interoperable with Thumb ISA:-)
 #endif
-.size	sha1_block_data_order,.-sha1_block_data_order
+.size	sha1_block_data_order_ARM,.-sha1_block_data_order_ARM
 
 .align	5
 .LK_00_19:.word	0x5a827999

--- a/sha1_armv4.h
+++ b/sha1_armv4.h
@@ -11,7 +11,7 @@ extern "C" {
 
 /* Crypto++ modifed sha1_block_data_order to pass caps as a parameter. */
 /* Also see https://github.com/weidai11/cryptopp/issues/846.           */
-void sha1_block_data_order(void *state, const void *data, size_t blocks);
+void sha1_block_data_order_ARM(void *state, const void *data, size_t blocks);
 
 /* Cryptogams arm caps */
 #define ARMV7_NEON (1<<0)


### PR DESCRIPTION
When compiling for armeabi-v7a  (Android) and have openssl compiled as well for the platform, when linking a library against both libraries the linker throws errors:
```
arm-linux-androideabi/bin/ld: error: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcryptopp.a(aes_armv4.o): multiple definition of 'AES_set_decrypt_key'
arm-linux-androideabi/bin/ld: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcrypto.a(aes-armv4.o): previous definition here
arm-linux-androideabi/bin/ld: error: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcryptopp.a(aes_armv4.o): multiple definition of 'AES_set_enc2dec_key'
arm-linux-androideabi/bin/ld: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcrypto.a(aes-armv4.o): previous definition here
arm-linux-androideabi/bin/ld: error: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcryptopp.a(aes_armv4.o): multiple definition of 'AES_set_encrypt_key'
arm-linux-androideabi/bin/ld: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcrypto.a(aes-armv4.o): previous definition here
arm-linux-androideabi/bin/ld: error Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcryptopp.a(sha1_armv4.o): multiple definition of 'sha1_block_data_order'
arm-linux-androideabi/bin/ld: Android/Sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/local/lib/libcrypto.a(sha1-armv4-large.o): previous definition here

```

On arm64-v8a works just fine.