### PR TITLE
Clear failbit after failed istream::seekg()

### DIFF
--- a/files.cpp
+++ b/files.cpp
@@ -67,6 +67,7 @@ lword FileStore::MaxRetrievable() const
 
 	std::streampos current = m_stream->tellg();
 	std::streampos end = m_stream->seekg(0, std::ios::end).tellg();
+	m_stream->clear();
 	m_stream->seekg(current);
 	return end-current;
 }


### PR DESCRIPTION
`std::istream` does not generally need to support seek-to-end behavior; it depends on the underlying `std::streambuf` implementation. If it fails the stream will set `failbit`, after which any further operation would fail until it is cleared.

Reference:
 - https://en.cppreference.com/w/cpp/io/basic_istream/seekg
 - https://en.cppreference.com/w/cpp/io/basic_streambuf/pubseekoff

This issue surfaced in [my use case](https://github.com/tanzislam/cryptopals/issues/32) after 04dee2a46, as I am using several `std::streambuf`-derived classes as streaming codecs and they do not support a seek-to-end functionality.