### PR TITLE
Fix gcc 11 c++20 compilation error with SourceTemplate constructor

### DIFF
--- a/filters.h
+++ b/filters.h
@@ -1432,7 +1432,7 @@ public:
 
 	/// \brief Construct a SourceTemplate
 	/// \param attachment an attached transformation
-	SourceTemplate<T>(BufferedTransformation *attachment)
+	SourceTemplate(BufferedTransformation *attachment)
 		: Source(attachment) {}
 	void IsolatedInitialize(const NameValuePairs &parameters)
 		{m_store.IsolatedInitialize(parameters);}


### PR DESCRIPTION
filters.h:1369:49: error: expected ‘)’ before ‘*’ token
 |         SourceTemplate<T>(BufferedTransformation *attachment)