### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -84,7 +84,7 @@ Other features include:
       + ARM-32, Aarch32 and Aarch64 provides NEON, ASIMD and ARMv8 implementations
       + Power8 provides in-core AES using NX Crypto Acceleration
 
-The Crypto++ library was orginally written by Wei Dai. The library is now
+The Crypto++ library was originally written by Wei Dai. The library is now
 maintained by several team members and the community. You are welcome to use it
 for any purpose without paying anyone, but see License.txt for the fine print.
 
@@ -248,7 +248,7 @@ The source code and its planned changes are available at the following locations
 
   * The Crypto++ GitHub repository allows you to view the latest (unreleased)
     Crypto++ source code via the Linux kernel's git beginning around June 2015.
-    Its also serves as an incubator to nuture and grow the library.
+    Its also serves as an incubator to nurture and grow the library.
   * The former Crypto++ SourceForge repository allows you to view the Crypto++
     source code via Apache's subversion until about July 2015. At that time,
     SourceForge had infrastructure problems and a cutover to GutHub was performed.

--- a/adv_simd.h
+++ b/adv_simd.h
@@ -7,7 +7,7 @@
 //    have a commom pattern. Namely, they have a specialized implementation of
 //    AdvancedProcessBlocks which processes multiple block using hardware
 //    acceleration. After several implementations we noticed a lot of copy and
-//    paste occuring. adv_simd.h provides a template to avoid the copy and paste.
+//    paste occurring. adv_simd.h provides a template to avoid the copy and paste.
 //
 //    There are 6 templates provided in this file. The number following the
 //    function name, 128, is the block size in bits. The name following the

--- a/config_asm.h
+++ b/config_asm.h
@@ -31,7 +31,7 @@
 // compiled using C++ only. The library code will not include SSE2 (and
 // above), NEON, Aarch32, Aarch64, or Altivec (and above). Note the compiler
 // may use higher ISAs depending on compiler options, but the library will not
-// explictly use the ISAs. When disabling ASM, it is best to do it from
+// explicitly use the ISAs. When disabling ASM, it is best to do it from
 // config.h to ensure the library and all programs share the setting.
 // #define CRYPTOPP_DISABLE_ASM 1
 
@@ -108,7 +108,7 @@
 # endif
 #endif
 
-// Intrinsics availible in GCC 4.3 (http://gcc.gnu.org/gcc-4.3/changes.html) and
+// Intrinsics available in GCC 4.3 (http://gcc.gnu.org/gcc-4.3/changes.html) and
 // MSVC 2008 (http://msdn.microsoft.com/en-us/library/bb892950%28v=vs.90%29.aspx)
 // SunCC could generate SSE4 at 12.1, but the intrinsics are missing until 12.4.
 #if !defined(CRYPTOPP_DISABLE_SSE4) && defined(CRYPTOPP_SSSE3_AVAILABLE) && \

--- a/cpu.h
+++ b/cpu.h
@@ -17,7 +17,7 @@
 ///    g_hasAES  = CPU_QueryAES() || CPU_ProbeAES();
 /// </pre>
 /// \details Generally speaking, CPU_Query() is in the source file <tt>cpu.cpp</tt> because it
-///  does not require special architectural flags. CPU_Probe() is in a source file that recieves
+///  does not require special architectural flags. CPU_Probe() is in a source file that receives
 ///  architectural flags, like <tt>sse_simd.cpp</tt>, <tt>neon_simd.cpp</tt> and
 ///  <tt>ppc_simd.cpp</tt>. For example, compiling <tt>neon_simd.cpp</tt> on an ARM64 machine will
 ///  have <tt>-march=armv8-a</tt> applied during a compile to make the instruction set architecture

--- a/cryptlib.cpp
+++ b/cryptlib.cpp
@@ -1018,7 +1018,7 @@ int LibraryVersion(CRYPTOPP_NOINLINE_DOTDOTDOT)
 class NullNameValuePairs : public NameValuePairs
 {
 public:
-	NullNameValuePairs() {}    //  Clang complains a default ctor must be avilable
+	NullNameValuePairs() {}    //  Clang complains a default ctor must be available
 	bool GetVoidValue(const char *name, const std::type_info &valueType, void *pValue) const
 		{CRYPTOPP_UNUSED(name); CRYPTOPP_UNUSED(valueType); CRYPTOPP_UNUSED(pValue); return false;}
 };

--- a/default.h
+++ b/default.h
@@ -125,14 +125,14 @@ public:
 	/// \brief Constructs a DataDecryptor
 	/// \param passphrase a C-String password
 	/// \param attachment a BufferedTransformation to attach to this object
-	/// \param throwException a flag specifiying whether an Exception should be thrown on error
+	/// \param throwException a flag specifying whether an Exception should be thrown on error
 	DataDecryptor(const char *passphrase, BufferedTransformation *attachment = NULLPTR, bool throwException=true);
 
 	/// \brief Constructs a DataDecryptor
 	/// \param passphrase a byte string password
 	/// \param passphraseLength the length of the byte string password
 	/// \param attachment a BufferedTransformation to attach to this object
-	/// \param throwException a flag specifiying whether an Exception should be thrown on error
+	/// \param throwException a flag specifying whether an Exception should be thrown on error
 	DataDecryptor(const byte *passphrase, size_t passphraseLength, BufferedTransformation *attachment = NULLPTR, bool throwException=true);
 
 	enum State {WAITING_FOR_KEYCHECK, KEY_GOOD, KEY_BAD};
@@ -227,14 +227,14 @@ public:
 	/// \brief Constructs a DataDecryptor
 	/// \param passphrase a C-String password
 	/// \param attachment a BufferedTransformation to attach to this object
-	/// \param throwException a flag specifiying whether an Exception should be thrown on error
+	/// \param throwException a flag specifying whether an Exception should be thrown on error
 	DataDecryptorWithMAC(const char *passphrase, BufferedTransformation *attachment = NULLPTR, bool throwException=true);
 
 	/// \brief Constructs a DataDecryptor
 	/// \param passphrase a byte string password
 	/// \param passphraseLength the length of the byte string password
 	/// \param attachment a BufferedTransformation to attach to this object
-	/// \param throwException a flag specifiying whether an Exception should be thrown on error
+	/// \param throwException a flag specifying whether an Exception should be thrown on error
 	DataDecryptorWithMAC(const byte *passphrase, size_t passphraseLength, BufferedTransformation *attachment = NULLPTR, bool throwException=true);
 
 	typename DataDecryptor<BC,H,Info>::State CurrentState() const;

--- a/drbg.h
+++ b/drbg.h
@@ -127,12 +127,12 @@ public:
     virtual unsigned int MaxNonceLength() const=0;
 
     /// \brief Provides the maximum size of a request to GenerateBlock
-    /// \return The the maximum size of a request to GenerateBlock(), in bytes
+    /// \return The maximum size of a request to GenerateBlock(), in bytes
     /// \details The equivalent class constant is <tt>MAXIMUM_BYTES_PER_REQUEST</tt>
     virtual unsigned int MaxBytesPerRequest() const=0;
 
     /// \brief Provides the maximum number of requests before a reseed
-    /// \return The the maximum number of requests before a reseed, in bytes
+    /// \return The maximum number of requests before a reseed, in bytes
     /// \details The equivalent class constant is <tt>MAXIMUM_REQUESTS_BEFORE_RESEED</tt>.
     ///  <tt>MAXIMUM_REQUESTS_BEFORE_RESEED</tt> has been reduced from 2<sup>48</sup> to <tt>INT_MAX</tt>
     ///  to fit the underlying C++ datatype.

--- a/filters.cpp
+++ b/filters.cpp
@@ -701,7 +701,7 @@ void StreamTransformationFilter::LastPut(const byte *inString, size_t length)
 	// This block is new to StreamTransformationFilter. It is somewhat of a hack and was
 	//  added for OCB mode; see GitHub Issue 515. The rub with OCB is, its a block cipher
 	//  and the last block size can be 0. However, "last block = 0" is not the 0 predicated
-	//  in the original code. In the orginal code 0 means "nothing special" so
+	//  in the original code. In the original code 0 means "nothing special" so
 	//  DEFAULT_PADDING is applied. OCB's 0 literally means a final block size can be 0 or
 	//  non-0; and no padding is needed in either case because OCB has its own scheme (see
 	//  handling of P_* and A_*).

--- a/nbtheory.cpp
+++ b/nbtheory.cpp
@@ -490,7 +490,7 @@ Integer MihailescuProvablePrime(RandomNumberGenerator &rng, unsigned int pbits)
 		// progression p = p_0 + \lambda * q2 = p_0 + 2 * \lambda * q,
 		// with q the recursively generated prime above. We will be able
 		// to use Lucas tets for proving primality. A trick of Quisquater
-		// allows taking q > cubic_root(p) rather then square_root: this
+		// allows taking q > cubic_root(p) rather than square_root: this
 		// decreases the recursion.
 
 		p.Randomize(rng, minP, maxP, Integer::ANY, 1, q2);

--- a/nbtheory.h
+++ b/nbtheory.h
@@ -105,7 +105,7 @@ CRYPTOPP_DLL bool CRYPTOPP_API IsPrime(const Integer &p);
 /// \param level the level of thoroughness of testing
 /// \return true if p is a strong probable prime, false otherwise
 /// \details VerifyPrime() is suitable for testing candidate primes created by others. Internally,
-///   VerifyPrime() utilizes IsPrime() and one-round RabinMillerTest(). If the candiate passes and
+///   VerifyPrime() utilizes IsPrime() and one-round RabinMillerTest(). If the candidate passes and
 ///   level is greater than 1, then 10 round RabinMillerTest() primality testing is performed.
 CRYPTOPP_DLL bool CRYPTOPP_API VerifyPrime(RandomNumberGenerator &rng, const Integer &p, unsigned int level = 1);
 

--- a/osrng.h
+++ b/osrng.h
@@ -140,7 +140,7 @@ protected:
 
 /// OS_GenerateRandomBlock
 /// \brief Generate random array of bytes
-/// \param blocking specifies whther a bobcking or non-blocking generator should be used
+/// \param blocking specifies whether a blocking or non-blocking generator should be used
 /// \param output the byte buffer
 /// \param size the length of the buffer, in bytes
 /// \details OS_GenerateRandomBlock() uses the underlying operating system's

--- a/pssr.h
+++ b/pssr.h
@@ -1,7 +1,7 @@
 // pssr.h - originally written and placed in the public domain by Wei Dai
 
 /// \file pssr.h
-/// \brief Classes for probablistic signature schemes
+/// \brief Classes for probabilistic signature schemes
 /// \since Crypto++ 2.1
 
 #ifndef CRYPTOPP_PSSR_H

--- a/simple.h
+++ b/simple.h
@@ -47,7 +47,7 @@ public:
 	/// \brief The algorithm name
 	/// \return the algorithm name
 	/// \details AlgorithmName returns the algorithm's name as a member function.
-	///  The name is is acquired by calling StaticAlgorithmName.
+	///  The name is acquired by calling StaticAlgorithmName.
 	std::string AlgorithmName() const {return ALGORITHM_INFO::StaticAlgorithmName();}
 };
 


### PR DESCRIPTION
Just a few typos in the documentation, and a few more in comments :)