### PR TITLE
Avoid memcpy in AdditiveCipherTemplate<S>::ProcessData (GH #683, GH #1010)

### DIFF
--- a/dll.cpp
+++ b/dll.cpp
@@ -23,7 +23,7 @@
 NAMESPACE_BEGIN(CryptoPP)
 
 // Guarding based on DLL due to Clang, http://github.com/weidai11/cryptopp/issues/300
-#if defined(CRYPTOPP_IS_DLL)
+#ifdef CRYPTOPP_IS_DLL
 template<> const byte PKCS_DigestDecoration<SHA1>::decoration[] = {0x30,0x21,0x30,0x09,0x06,0x05,0x2B,0x0E,0x03,0x02,0x1A,0x05,0x00,0x04,0x14};
 template<> const unsigned int PKCS_DigestDecoration<SHA1>::length = sizeof(PKCS_DigestDecoration<SHA1>::decoration);
 

--- a/strciphr.cpp
+++ b/strciphr.cpp
@@ -74,7 +74,7 @@ void AdditiveCipherTemplate<S>::ProcessData(byte *outString, const byte *inStrin
 	CRYPTOPP_ASSERT(length % this->MandatoryBlockSize() == 0);
 
 	PolicyInterface &policy = this->AccessPolicy();
-	word32 bytesPerIteration = policy.GetBytesPerIteration();
+	unsigned int bytesPerIteration = policy.GetBytesPerIteration();
 
 	if (m_leftOver > 0)
 	{
@@ -88,7 +88,7 @@ void AdditiveCipherTemplate<S>::ProcessData(byte *outString, const byte *inStrin
 
 	if (!length) {return;}
 
-	const word32 alignment = policy.GetAlignment();
+	const unsigned int alignment = policy.GetAlignment();
 	const bool inAligned = IsAlignedOn(inString, alignment);
 	const bool outAligned = IsAlignedOn(outString, alignment);
 
@@ -127,6 +127,7 @@ void AdditiveCipherTemplate<S>::ProcessData(byte *outString, const byte *inStrin
 
 		policy.WriteKeystream(PtrSub(KeystreamBufferEnd(), bufferByteSize), bufferIterations);
 		xorbuf(outString, inString, PtrSub(KeystreamBufferEnd(), bufferByteSize), length);
+
 		m_leftOver = bufferByteSize - length;
 	}
 }
@@ -144,7 +145,7 @@ template <class BASE>
 void AdditiveCipherTemplate<BASE>::Seek(lword position)
 {
 	PolicyInterface &policy = this->AccessPolicy();
-	word32 bytesPerIteration = policy.GetBytesPerIteration();
+	unsigned int bytesPerIteration = policy.GetBytesPerIteration();
 
 	policy.SeekToIteration(position / bytesPerIteration);
 	position %= bytesPerIteration;
@@ -152,7 +153,7 @@ void AdditiveCipherTemplate<BASE>::Seek(lword position)
 	if (position > 0)
 	{
 		policy.WriteKeystream(PtrSub(KeystreamBufferEnd(), bytesPerIteration), 1);
-		m_leftOver = bytesPerIteration - static_cast<word32>(position);
+		m_leftOver = bytesPerIteration - static_cast<unsigned int>(position);
 	}
 	else
 		m_leftOver = 0;
@@ -189,7 +190,7 @@ void CFB_CipherTemplate<BASE>::ProcessData(byte *outString, const byte *inString
 	CRYPTOPP_ASSERT(length % this->MandatoryBlockSize() == 0);
 
 	PolicyInterface &policy = this->AccessPolicy();
-	word32 bytesPerIteration = policy.GetBytesPerIteration();
+	unsigned int bytesPerIteration = policy.GetBytesPerIteration();
 	byte *reg = policy.GetRegisterBegin();
 
 	if (m_leftOver)
@@ -213,7 +214,7 @@ void CFB_CipherTemplate<BASE>::ProcessData(byte *outString, const byte *inString
 	//
 	//       Also see https://github.com/weidai11/cryptopp/issues/683.
 
-	const word32 alignment = policy.GetAlignment();
+	const unsigned int alignment = policy.GetAlignment();
 	const bool inAligned = IsAlignedOn(inString, alignment);
 	const bool outAligned = IsAlignedOn(outString, alignment);
 

--- a/strciphr.cpp
+++ b/strciphr.cpp
@@ -97,7 +97,7 @@ void AdditiveCipherTemplate<S>::ProcessData(byte *outString, const byte *inStrin
 		const size_t iterations = length / bytesPerIteration;
 		KeystreamOperationFlags flags = static_cast<KeystreamOperationFlags>(
 			(inAligned ? EnumToInt(INPUT_ALIGNED) : 0) | (outAligned ? EnumToInt(OUTPUT_ALIGNED) : 0));
-		const KeystreamOperation operation = KeystreamOperation(flags);
+		KeystreamOperation operation = KeystreamOperation(flags);
 
 		policy.OperateKeystream(operation, outString, inString, iterations);
 		s_workaround = const_cast<volatile byte*>(outString);

--- a/strciphr.h
+++ b/strciphr.h
@@ -702,13 +702,16 @@ public:
 
 NAMESPACE_END
 
+// Used by dll.cpp to ensure objects are in dll.o, and not strciphr.o.
 #ifdef CRYPTOPP_MANUALLY_INSTANTIATE_TEMPLATES
-#include "strciphr.cpp"
+# include "strciphr.cpp"
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)
+
 CRYPTOPP_DLL_TEMPLATE_CLASS AbstractPolicyHolder<AdditiveCipherAbstractPolicy, SymmetricCipher>;
 CRYPTOPP_DLL_TEMPLATE_CLASS AdditiveCipherTemplate<AbstractPolicyHolder<AdditiveCipherAbstractPolicy, SymmetricCipher> >;
+
 CRYPTOPP_DLL_TEMPLATE_CLASS CFB_CipherTemplate<AbstractPolicyHolder<CFB_CipherAbstractPolicy, SymmetricCipher> >;
 CRYPTOPP_DLL_TEMPLATE_CLASS CFB_EncryptionTemplate<AbstractPolicyHolder<CFB_CipherAbstractPolicy, SymmetricCipher> >;
 CRYPTOPP_DLL_TEMPLATE_CLASS CFB_DecryptionTemplate<AbstractPolicyHolder<CFB_CipherAbstractPolicy, SymmetricCipher> >;


### PR DESCRIPTION
We found we can avoid the memcpy in the previous workaround by using a volatile pointer. The pointer appears to tame the optimizer so the compiler does not short-circuit some calls when outString == inString.