### PR TITLE
Allow building with Intel oneAPI DPC++/C++ compiler

### DIFF
--- a/config_os.h
+++ b/config_os.h
@@ -29,7 +29,7 @@
 // https://www.cryptopp.com/wiki/Release_Process#Self_Tests
 // Some relevant bug reports can be found at:
 // * Clang: http://github.com/weidai11/cryptopp/issues/147
-#if (defined(_MSC_VER) && defined(__clang__) && !(defined( __clang_analyzer__)))
+#if (defined(_MSC_VER) && defined(__clang__) && !(defined( __clang_analyzer__)) && !defined(__INTEL_LLVM_COMPILER))
 # error: "Unsupported configuration"
 #endif
 


### PR DESCRIPTION
This new Clang-based compiler (`icx`) apparently #defines `__CLANG__`, even
though it is not documented.
https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compiler-reference/macros/use-predefined-macros-for-intel-compilers.html