### PR TITLE
Implement SIMD checks for FreeBSD/powerpc*

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -1208,6 +1208,11 @@ inline bool CPU_QueryAltivec()
 	unsigned int unused, arch;
 	GetAppleMachineInfo(unused, unused, arch);
 	return arch == AppleMachineInfo::PowerMac;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE_HAS_ALTIVEC)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE_HAS_ALTIVEC;
 #endif
 	return false;
 }
@@ -1221,6 +1226,11 @@ inline bool CPU_QueryPower7()
 #elif defined(_AIX)
 	if (__power_7_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE_ARCH_2_06)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE_ARCH_2_06;
 #endif
 	return false;
 }
@@ -1234,6 +1244,11 @@ inline bool CPU_QueryPower8()
 #elif defined(_AIX)
 	if (__power_8_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_ARCH_2_07)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_ARCH_2_07;
 #endif
 	return false;
 }
@@ -1247,6 +1262,11 @@ inline bool CPU_QueryPower9()
 #elif defined(_AIX)
 	if (__power_9_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_ARCH_3_00)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE_ARCH2_3_00;
 #endif
 	return false;
 }
@@ -1261,6 +1281,11 @@ inline bool CPU_QueryAES()
 #elif defined(_AIX)
 	if (__power_8_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_VEC_CRYPTO)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO;
 #endif
 	return false;
 }
@@ -1275,6 +1300,11 @@ inline bool CPU_QueryPMULL()
 #elif defined(_AIX)
 	if (__power_8_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_VEC_CRYPTO)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO;
 #endif
 	return false;
 }
@@ -1289,6 +1319,11 @@ inline bool CPU_QuerySHA256()
 #elif defined(_AIX)
 	if (__power_8_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_VEC_CRYPTO)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO;
 #endif
 	return false;
 }
@@ -1302,6 +1337,11 @@ inline bool CPU_QuerySHA512()
 #elif defined(_AIX)
 	if (__power_8_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_VEC_CRYPTO)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_HAS_VEC_CRYPTO;
 #endif
 	return false;
 }
@@ -1316,6 +1356,11 @@ inline bool CPU_QueryDARN()
 #elif defined(_AIX)
 	if (__power_9_andup() != 0)
 		return true;
+#elif defined(__FreeBSD__) && defined(PPC_FEATURE2_ARCH_3_00)
+	unsigned long cpufeatures;
+	if (elf_aux_info(AT_HWCAP2, &cpufeatures, sizeof(cpufeatures))
+		return false;
+	else return cpufeatures & PPC_FEATURE2_ARCH_3_00;
 #endif
 	return false;
 }


### PR DESCRIPTION
FreeBSD uses elf_aux_info() instead of getauxval().