### PR TITLE
Added overloaded functions in the donna source files that let the caller specify a HashTransformation

### DIFF
--- a/donna.h
+++ b/donna.h
@@ -41,7 +41,7 @@ NAMESPACE_BEGIN(Donna)
 /// \details curve25519_mult() generates a public key from an existing
 ///   secret key. Internally curve25519_mult() performs a scalar
 ///   multiplication using the base point and writes the result to
-///   <tt>pubkey</tt>.
+///   <tt>publicKey</tt>.
 int curve25519_mult(byte publicKey[32], const byte secretKey[32]);
 
 /// \brief Generate a shared key
@@ -66,6 +66,16 @@ int curve25519_mult(byte sharedKey[32], const byte secretKey[32], const byte oth
 ///   using the secret key and then writes the result to <tt>publicKey</tt>.
 int ed25519_publickey(byte publicKey[32], const byte secretKey[32]);
 
+/// \brief Creates a public key from a secret key
+/// \param publicKey byte array for the public key
+/// \param secretKey byte array with the private key
+/// \param hash HashTransformation derived class
+/// \return 0 on success, non-0 otherwise
+/// \details ed25519_publickey() generates a public key from a secret key.
+///   Internally ed25519_publickey() performs a scalar multiplication
+///   using the secret key and then writes the result to <tt>publicKey</tt>.
+int ed25519_publickey(byte publicKey[32], const byte secretKey[32], HashTransformation& hash);
+
 /// \brief Creates a signature on a message
 /// \param message byte array with the message
 /// \param messageLength size of the message, in bytes
@@ -80,6 +90,22 @@ int ed25519_publickey(byte publicKey[32], const byte secretKey[32]);
 /// \details At the moment the hash function for signing is fixed at
 ///   SHA512.
 int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32], const byte publicKey[32], byte signature[64]);
+
+/// \brief Creates a signature on a message
+/// \param message byte array with the message
+/// \param messageLength size of the message, in bytes
+/// \param publicKey byte array with the public key
+/// \param secretKey byte array with the private key
+/// \param signature byte array for the signature
+/// \param hash HashTransformation derived class
+/// \return 0 on success, non-0 otherwise
+/// \details ed25519_sign() generates a signature on a message using
+///   the public and private keys. The various buffers can be exact
+///   sizes, and do not require extra space like when using the
+///   NaCl library functions.
+/// \details At the moment the hash function for signing is fixed at
+///   SHA512.
+int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32], const byte publicKey[32], byte signature[64], HashTransformation& hash);
 
 /// \brief Creates a signature on a message
 /// \param stream std::istream derived class
@@ -98,6 +124,24 @@ int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey
 ///   SHA512.
 int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32], byte signature[64]);
 
+/// \brief Creates a signature on a message
+/// \param stream std::istream derived class
+/// \param publicKey byte array with the public key
+/// \param secretKey byte array with the private key
+/// \param signature byte array for the signature
+/// \param hash HashTransformation derived class
+/// \return 0 on success, non-0 otherwise
+/// \details ed25519_sign() generates a signature on a message using
+///   the public and private keys. The various buffers can be exact
+///   sizes, and do not require extra space like when using the
+///   NaCl library functions.
+/// \details This ed25519_sign() overload handles large streams. It
+///   was added for signing and verifying files that are too large
+///   for a memory allocation.
+/// \details At the moment the hash function for signing is fixed at
+///   SHA512.
+int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32], byte signature[64], HashTransformation& hash);
+
 /// \brief Verifies a signature on a message
 /// \param message byte array with the message
 /// \param messageLength size of the message, in bytes
@@ -110,7 +154,22 @@ int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publ
 /// \details At the moment the hash function for signing is fixed at
 ///   SHA512.
 int
-ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKey[32], const byte signature[64]);
+ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKey[32], const byte signature[64]);
+
+/// \brief Verifies a signature on a message
+/// \param message byte array with the message
+/// \param messageLength size of the message, in bytes
+/// \param publicKey byte array with the public key
+/// \param signature byte array with the signature
+/// \param hash HashTransformation derived class
+/// \return 0 on success, non-0 otherwise
+/// \details ed25519_sign_open() verifies a signature on a message using
+///   the public key. The various buffers can be exact sizes, and do not
+///   require extra space like when using the NaCl library functions.
+/// \details At the moment the hash function for signing is fixed at
+///   SHA512.
+int
+ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKey[32], const byte signature[64], HashTransformation& hash);
 
 /// \brief Verifies a signature on a message
 /// \param stream std::istream derived class
@@ -127,6 +186,23 @@ ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKe
 ///   SHA512.
 int
 ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64]);
+
+/// \brief Verifies a signature on a message
+/// \param stream std::istream derived class
+/// \param publicKey byte array with the public key
+/// \param signature byte array with the signature
+/// \param hash HashTransformation derived class
+/// \return 0 on success, non-0 otherwise
+/// \details ed25519_sign_open() verifies a signature on a message using
+///   the public key. The various buffers can be exact sizes, and do not
+///   require extra space like when using the NaCl library functions.
+/// \details This ed25519_sign_open() overload handles large streams. It
+///   was added for signing and verifying files that are too large
+///   for a memory allocation.
+/// \details At the moment the hash function for signing is fixed at
+///   SHA512.
+int
+ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64], HashTransformation& hash);
 
 //****************************** Internal ******************************//
 

--- a/donna.h
+++ b/donna.h
@@ -18,10 +18,11 @@
 /// \details This header provides the entry points into Andrew Moon's
 ///   curve25519 and ed25519 curve functions. The Crypto++ classes x25519
 ///   and ed25519 use the functions. The functions are in the <tt>Donna</tt>
-///   namespace and are curve25519_mult(), ed25519_publickey(),
-///   ed25519_sign() and ed25519_sign_open().
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
+///   namespace are curve25519_mult(), ed25519_publickey(), ed25519_sign(),
+///   and ed25519_sign_open().
+/// \details By default, the ed25519 functions use SHA512, but they have
+///   overloads added by Ashwin Innuganti that let the caller specify any
+///   HashTransformation with 512-bit digests.
 
 #ifndef CRYPTOPP_DONNA_H
 #define CRYPTOPP_DONNA_H
@@ -69,7 +70,7 @@ int ed25519_publickey(byte publicKey[32], const byte secretKey[32]);
 /// \brief Creates a public key from a secret key
 /// \param publicKey byte array for the public key
 /// \param secretKey byte array with the private key
-/// \param hash HashTransformation derived class
+/// \param hash HashTransformation derived class (digest size should be 512 bits)
 /// \return 0 on success, non-0 otherwise
 /// \details ed25519_publickey() generates a public key from a secret key.
 ///   Internally ed25519_publickey() performs a scalar multiplication
@@ -87,8 +88,6 @@ int ed25519_publickey(byte publicKey[32], const byte secretKey[32], HashTransfor
 ///   the public and private keys. The various buffers can be exact
 ///   sizes, and do not require extra space like when using the
 ///   NaCl library functions.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32], const byte publicKey[32], byte signature[64]);
 
 /// \brief Creates a signature on a message
@@ -97,14 +96,12 @@ int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey
 /// \param publicKey byte array with the public key
 /// \param secretKey byte array with the private key
 /// \param signature byte array for the signature
-/// \param hash HashTransformation derived class
+/// \param hash HashTransformation derived class (digest size should be 512 bits)
 /// \return 0 on success, non-0 otherwise
 /// \details ed25519_sign() generates a signature on a message using
 ///   the public and private keys. The various buffers can be exact
 ///   sizes, and do not require extra space like when using the
 ///   NaCl library functions.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32], const byte publicKey[32], byte signature[64], HashTransformation& hash);
 
 /// \brief Creates a signature on a message
@@ -120,8 +117,6 @@ int ed25519_sign(const byte* message, size_t messageLength, const byte secretKey
 /// \details This ed25519_sign() overload handles large streams. It
 ///   was added for signing and verifying files that are too large
 ///   for a memory allocation.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32], byte signature[64]);
 
 /// \brief Creates a signature on a message
@@ -129,7 +124,7 @@ int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publ
 /// \param publicKey byte array with the public key
 /// \param secretKey byte array with the private key
 /// \param signature byte array for the signature
-/// \param hash HashTransformation derived class
+/// \param hash HashTransformation derived class (digest size should be 512 bits)
 /// \return 0 on success, non-0 otherwise
 /// \details ed25519_sign() generates a signature on a message using
 ///   the public and private keys. The various buffers can be exact
@@ -138,8 +133,6 @@ int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publ
 /// \details This ed25519_sign() overload handles large streams. It
 ///   was added for signing and verifying files that are too large
 ///   for a memory allocation.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32], byte signature[64], HashTransformation& hash);
 
 /// \brief Verifies a signature on a message
@@ -151,8 +144,6 @@ int ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publ
 /// \details ed25519_sign_open() verifies a signature on a message using
 ///   the public key. The various buffers can be exact sizes, and do not
 ///   require extra space like when using the NaCl library functions.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int
 ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKey[32], const byte signature[64]);
 
@@ -161,13 +152,11 @@ ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKe
 /// \param messageLength size of the message, in bytes
 /// \param publicKey byte array with the public key
 /// \param signature byte array with the signature
-/// \param hash HashTransformation derived class
+/// \param hash HashTransformation derived class (digest size should be 512 bits)
 /// \return 0 on success, non-0 otherwise
 /// \details ed25519_sign_open() verifies a signature on a message using
 ///   the public key. The various buffers can be exact sizes, and do not
 ///   require extra space like when using the NaCl library functions.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int
 ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKey[32], const byte signature[64], HashTransformation& hash);
 
@@ -182,8 +171,6 @@ ed25519_sign_open(const byte* message, size_t messageLength, const byte publicKe
 /// \details This ed25519_sign_open() overload handles large streams. It
 ///   was added for signing and verifying files that are too large
 ///   for a memory allocation.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int
 ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64]);
 
@@ -191,7 +178,7 @@ ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte sig
 /// \param stream std::istream derived class
 /// \param publicKey byte array with the public key
 /// \param signature byte array with the signature
-/// \param hash HashTransformation derived class
+/// \param hash HashTransformation derived class (digest size should be 512 bits)
 /// \return 0 on success, non-0 otherwise
 /// \details ed25519_sign_open() verifies a signature on a message using
 ///   the public key. The various buffers can be exact sizes, and do not
@@ -199,8 +186,6 @@ ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte sig
 /// \details This ed25519_sign_open() overload handles large streams. It
 ///   was added for signing and verifying files that are too large
 ///   for a memory allocation.
-/// \details At the moment the hash function for signing is fixed at
-///   SHA512.
 int
 ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64], HashTransformation& hash);
 

--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -1071,8 +1071,21 @@ ed25519_hash(byte *hash, const byte *in, size_t inlen) {
 }
 
 inline void
+ed25519_hash(byte *hash, const byte *in, size_t inlen, HashTransformation& hashTf) {
+    hashTf.CalculateDigest(hash, in, inlen);
+}
+
+inline void
 ed25519_extsk(hash_512bits extsk, const byte sk[32]) {
     ed25519_hash(extsk, sk, 32);
+    extsk[0] &= 248;
+    extsk[31] &= 127;
+    extsk[31] |= 64;
+}
+
+inline void
+ed25519_extsk(hash_512bits extsk, const byte sk[32], HashTransformation& hash) {
+    ed25519_hash(extsk, sk, 32, hash);
     extsk[0] &= 248;
     extsk[31] &= 127;
     extsk[31] |= 64;
@@ -1102,8 +1115,28 @@ ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], const byte
 }
 
 void
+ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], const byte *m, size_t mlen,
+             HashTransformation& hash)
+{
+    hash.Update(RS, 32);
+    hash.Update(pk, 32);
+    hash.Update(m, mlen);
+    hash.Final(hram);
+}
+
+void
 ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], std::istream& stream) {
     SHA512 hash;
+    hash.Update(RS, 32);
+    hash.Update(pk, 32);
+    UpdateFromStream(hash, stream);
+    hash.Final(hram);
+}
+
+void
+ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], std::istream& stream,
+             HashTransformation& hash)
+{
     hash.Update(RS, 32);
     hash.Update(pk, 32);
     UpdateFromStream(hash, stream);
@@ -1921,9 +1954,33 @@ ed25519_publickey_CXX(byte publicKey[32], const byte secretKey[32])
 }
 
 int
+ed25519_publickey_CXX(byte publicKey[32], const byte secretKey[32], HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm a;
+    ALIGN(ALIGN_SPEC) ge25519 A;
+    hash_512bits extsk;
+
+    /* A = aB */
+    ed25519_extsk(extsk, secretKey, hash);
+    expand256_modm(a, extsk, 32);
+    ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
+    ge25519_pack(publicKey, &A);
+
+    return 0;
+}
+
+int
 ed25519_publickey(byte publicKey[32], const byte secretKey[32])
 {
     return ed25519_publickey_CXX(publicKey, secretKey);
+}
+
+int
+ed25519_publickey(byte publicKey[32], const byte secretKey[32], HashTransformation& hash)
+{
+    return ed25519_publickey_CXX(publicKey, secretKey, hash);
 }
 
 int
@@ -1960,6 +2017,55 @@ ed25519_sign_CXX(std::istream& stream, const byte sk[32], const byte pk[32], byt
 
     /* S = H(R,A,m).. */
     ed25519_hram(hram, RS, pk, stream);
+    expand256_modm(S, hram, 64);
+
+    /* S = H(R,A,m)a */
+    expand256_modm(a, extsk, 32);
+    mul256_modm(S, S, a);
+
+    /* S = (r + H(R,A,m)a) */
+    add256_modm(S, S, r);
+
+    /* S = (r + H(R,A,m)a) mod L */
+    contract256_modm(RS + 32, S);
+
+    return 0;
+}
+
+int
+ed25519_sign_CXX(std::istream& stream, const byte sk[32], const byte pk[32], byte RS[64],
+                 HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm r, S, a;
+    ALIGN(ALIGN_SPEC) ge25519 R;
+    hash_512bits extsk, hashr, hram;
+
+    // Unfortunately we need to read the stream twice. The fisrt time calculates
+    // 'r = H(aExt[32..64], m)'. The second time calculates 'S = H(R,A,m)'. There
+    // is a data dependency due to hashing 'RS' with 'R = [r]B' that does not
+    // allow us to read the stream once.
+    std::streampos where = stream.tellg();
+
+    ed25519_extsk(extsk, sk, hash);
+
+    /* r = H(aExt[32..64], m) */
+    hash.Update(extsk + 32, 32);
+    UpdateFromStream(hash, stream);
+    hash.Final(hashr);
+    expand256_modm(r, hashr, 64);
+
+    /* R = rB */
+    ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
+    ge25519_pack(RS, &R);
+
+    // Reset stream for the second digest
+    stream.clear();
+    stream.seekg(where);
+
+    /* S = H(R,A,m).. */
+    ed25519_hram(hram, RS, pk, stream, hash);
     expand256_modm(S, hram, 64);
 
     /* S = H(R,A,m)a */
@@ -2015,6 +2121,45 @@ ed25519_sign_CXX(const byte *m, size_t mlen, const byte sk[32], const byte pk[32
 }
 
 int
+ed25519_sign_CXX(const byte *m, size_t mlen, const byte sk[32], const byte pk[32], byte RS[64],
+                 HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm r, S, a;
+    ALIGN(ALIGN_SPEC) ge25519 R;
+    hash_512bits extsk, hashr, hram;
+
+    ed25519_extsk(extsk, sk, hash);
+
+    /* r = H(aExt[32..64], m) */
+    hash.Update(extsk + 32, 32);
+    hash.Update(m, mlen);
+    hash.Final(hashr);
+    expand256_modm(r, hashr, 64);
+
+    /* R = rB */
+    ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
+    ge25519_pack(RS, &R);
+
+    /* S = H(R,A,m).. */
+    ed25519_hram(hram, RS, pk, m, mlen, hash);
+    expand256_modm(S, hram, 64);
+
+    /* S = H(R,A,m)a */
+    expand256_modm(a, extsk, 32);
+    mul256_modm(S, S, a);
+
+    /* S = (r + H(R,A,m)a) */
+    add256_modm(S, S, r);
+
+    /* S = (r + H(R,A,m)a) mod L */
+    contract256_modm(RS + 32, S);
+
+    return 0;
+}
+
+int
 ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32],
              byte signature[64])
 {
@@ -2022,10 +2167,24 @@ ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKe
 }
 
 int
+ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32],
+             byte signature[64], HashTransformation& hash)
+{
+    return ed25519_sign_CXX(stream, secretKey, publicKey, signature, hash);
+}
+
+int
 ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32],
              const byte publicKey[32], byte signature[64])
 {
     return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature);
+}
+
+int
+ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32],
+             const byte publicKey[32], byte signature[64], HashTransformation& hash)
+{
+    return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature, hash);
 }
 
 int
@@ -2043,6 +2202,35 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
 
     /* hram = H(R,A,m) */
     ed25519_hram(hash, RS, pk, stream);
+    expand256_modm(hram, hash, 64);
+
+    /* S */
+    expand256_modm(S, RS + 32, 32);
+
+    /* SB - H(R,A,m)A */
+    ge25519_double_scalarmult_vartime(&R, &A, hram, S);
+    ge25519_pack(checkR, &R);
+
+    /* check that R = SB - H(R,A,m)A */
+    return ed25519_verify(RS, checkR, 32) ? 0 : -1;
+}
+
+int
+ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64],
+                      HashTransformation& hashTf)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    ALIGN(ALIGN_SPEC) ge25519 R, A;
+    hash_512bits hash;
+    bignum256modm hram, S;
+    byte checkR[32];
+
+    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+        return -1;
+
+    /* hram = H(R,A,m) */
+    ed25519_hram(hash, RS, pk, stream, hashTf);
     expand256_modm(hram, hash, 64);
 
     /* S */
@@ -2085,15 +2273,58 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
 }
 
 int
+ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte RS[64],
+                      HashTransformation& hashTf)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    ALIGN(ALIGN_SPEC) ge25519 R, A;
+    hash_512bits hash;
+    bignum256modm hram, S;
+    byte checkR[32];
+
+    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+        return -1;
+
+    /* hram = H(R,A,m) */
+    ed25519_hram(hash, RS, pk, m, mlen, hashTf);
+    expand256_modm(hram, hash, 64);
+
+    /* S */
+    expand256_modm(S, RS + 32, 32);
+
+    /* SB - H(R,A,m)A */
+    ge25519_double_scalarmult_vartime(&R, &A, hram, S);
+    ge25519_pack(checkR, &R);
+
+    /* check that R = SB - H(R,A,m)A */
+    return ed25519_verify(RS, checkR, 32) ? 0 : -1;
+}
+
+int
 ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKey[32], const byte signature[64])
 {
     return ed25519_sign_open_CXX(message, messageLength, publicKey, signature);
 }
 
 int
+ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKey[32], const byte signature[64],
+                  HashTransformation& hash)
+{
+    return ed25519_sign_open_CXX(message, messageLength, publicKey, signature, hash);
+}
+
+int
 ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64])
 {
     return ed25519_sign_open_CXX(stream, publicKey, signature);
+}
+
+int
+ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64],
+                  HashTransformation& hash)
+{
+    return ed25519_sign_open_CXX(stream, publicKey, signature, hash);
 }
 
 NAMESPACE_END  // Donna

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -819,8 +819,21 @@ ed25519_hash(byte *hash, const byte *in, size_t inlen) {
 }
 
 inline void
+ed25519_hash(byte *hash, const byte *in, size_t inlen, HashTransformation& hashTf) {
+    hashTf.CalculateDigest(hash, in, inlen);
+}
+
+inline void
 ed25519_extsk(hash_512bits extsk, const byte sk[32]) {
     ed25519_hash(extsk, sk, 32);
+    extsk[0] &= 248;
+    extsk[31] &= 127;
+    extsk[31] |= 64;
+}
+
+inline void
+ed25519_extsk(hash_512bits extsk, const byte sk[32], HashTransformation& hash) {
+    ed25519_hash(extsk, sk, 32, hash);
     extsk[0] &= 248;
     extsk[31] &= 127;
     extsk[31] |= 64;
@@ -850,8 +863,28 @@ ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], const byte
 }
 
 void
+ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], const byte *m, size_t mlen,
+             HashTransformation& hash)
+{
+    hash.Update(RS, 32);
+    hash.Update(pk, 32);
+    hash.Update(m, mlen);
+    hash.Final(hram);
+}
+
+void
 ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], std::istream& stream) {
     SHA512 hash;
+    hash.Update(RS, 32);
+    hash.Update(pk, 32);
+    UpdateFromStream(hash, stream);
+    hash.Final(hram);
+}
+
+void
+ed25519_hram(hash_512bits hram, const byte RS[64], const byte pk[32], std::istream& stream,
+             HashTransformation& hash)
+{
     hash.Update(RS, 32);
     hash.Update(pk, 32);
     UpdateFromStream(hash, stream);
@@ -1636,9 +1669,33 @@ ed25519_publickey_CXX(byte publicKey[32], const byte secretKey[32])
 }
 
 int
+ed25519_publickey_CXX(byte publicKey[32], const byte secretKey[32], HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm a;
+    ALIGN(ALIGN_SPEC) ge25519 A;
+    hash_512bits extsk;
+
+    /* A = aB */
+    ed25519_extsk(extsk, secretKey, hash);
+    expand256_modm(a, extsk, 32);
+    ge25519_scalarmult_base_niels(&A, ge25519_niels_base_multiples, a);
+    ge25519_pack(publicKey, &A);
+
+    return 0;
+}
+
+int
 ed25519_publickey(byte publicKey[32], const byte secretKey[32])
 {
     return ed25519_publickey_CXX(publicKey, secretKey);
+}
+
+int
+ed25519_publickey(byte publicKey[32], const byte secretKey[32], HashTransformation& hash)
+{
+    return ed25519_publickey_CXX(publicKey, secretKey, hash);
 }
 
 int
@@ -1690,6 +1747,55 @@ ed25519_sign_CXX(std::istream& stream, const byte sk[32], const byte pk[32], byt
 }
 
 int
+ed25519_sign_CXX(std::istream& stream, const byte sk[32], const byte pk[32], byte RS[64],
+                 HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm r, S, a;
+    ALIGN(ALIGN_SPEC) ge25519 R;
+    hash_512bits extsk, hashr, hram;
+
+    // Unfortunately we need to read the stream twice. The fisrt time calculates
+    // 'r = H(aExt[32..64], m)'. The second time calculates 'S = H(R,A,m)'. There
+    // is a data dependency due to hashing 'RS' with 'R = [r]B' that does not
+    // allow us to read the stream once.
+    std::streampos where = stream.tellg();
+
+    ed25519_extsk(extsk, sk, hash);
+
+    /* r = H(aExt[32..64], m) */
+    hash.Update(extsk + 32, 32);
+    UpdateFromStream(hash, stream);
+    hash.Final(hashr);
+    expand256_modm(r, hashr, 64);
+
+    /* R = rB */
+    ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
+    ge25519_pack(RS, &R);
+
+    // Reset stream for the second digest
+    stream.clear();
+    stream.seekg(where);
+
+    /* S = H(R,A,m).. */
+    ed25519_hram(hram, RS, pk, stream, hash);
+    expand256_modm(S, hram, 64);
+
+    /* S = H(R,A,m)a */
+    expand256_modm(a, extsk, 32);
+    mul256_modm(S, S, a);
+
+    /* S = (r + H(R,A,m)a) */
+    add256_modm(S, S, r);
+
+    /* S = (r + H(R,A,m)a) mod L */
+    contract256_modm(RS + 32, S);
+
+    return 0;
+}
+
+int
 ed25519_sign_CXX(const byte *m, size_t mlen, const byte sk[32], const byte pk[32], byte RS[64])
 {
     using namespace CryptoPP::Donna::Ed25519;
@@ -1728,6 +1834,45 @@ ed25519_sign_CXX(const byte *m, size_t mlen, const byte sk[32], const byte pk[32
 }
 
 int
+ed25519_sign_CXX(const byte *m, size_t mlen, const byte sk[32], const byte pk[32], byte RS[64],
+                 HashTransformation& hash)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    bignum256modm r, S, a;
+    ALIGN(ALIGN_SPEC) ge25519 R;
+    hash_512bits extsk, hashr, hram;
+
+    ed25519_extsk(extsk, sk, hash);
+
+    /* r = H(aExt[32..64], m) */
+    hash.Update(extsk + 32, 32);
+    hash.Update(m, mlen);
+    hash.Final(hashr);
+    expand256_modm(r, hashr, 64);
+
+    /* R = rB */
+    ge25519_scalarmult_base_niels(&R, ge25519_niels_base_multiples, r);
+    ge25519_pack(RS, &R);
+
+    /* S = H(R,A,m).. */
+    ed25519_hram(hram, RS, pk, m, mlen, hash);
+    expand256_modm(S, hram, 64);
+
+    /* S = H(R,A,m)a */
+    expand256_modm(a, extsk, 32);
+    mul256_modm(S, S, a);
+
+    /* S = (r + H(R,A,m)a) */
+    add256_modm(S, S, r);
+
+    /* S = (r + H(R,A,m)a) mod L */
+    contract256_modm(RS + 32, S);
+
+    return 0;
+}
+
+int
 ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32],
              byte signature[64])
 {
@@ -1735,10 +1880,24 @@ ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKe
 }
 
 int
+ed25519_sign(std::istream& stream, const byte secretKey[32], const byte publicKey[32],
+             byte signature[64], HashTransformation& hash)
+{
+    return ed25519_sign_CXX(stream, secretKey, publicKey, signature, hash);
+}
+
+int
 ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32],
              const byte publicKey[32], byte signature[64])
 {
     return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature);
+}
+
+int
+ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32],
+             const byte publicKey[32], byte signature[64], HashTransformation& hash)
+{
+    return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature, hash);
 }
 
 int
@@ -1756,6 +1915,35 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
 
     /* hram = H(R,A,m) */
     ed25519_hram(hash, RS, pk, m, mlen);
+    expand256_modm(hram, hash, 64);
+
+    /* S */
+    expand256_modm(S, RS + 32, 32);
+
+    /* SB - H(R,A,m)A */
+    ge25519_double_scalarmult_vartime(&R, &A, hram, S);
+    ge25519_pack(checkR, &R);
+
+    /* check that R = SB - H(R,A,m)A */
+    return ed25519_verify(RS, checkR, 32) ? 0 : -1;
+}
+
+int
+ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte RS[64],
+                      HashTransformation& hashTf)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    ALIGN(ALIGN_SPEC) ge25519 R, A;
+    hash_512bits hash;
+    bignum256modm hram, S;
+    byte checkR[32];
+
+    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+        return -1;
+
+    /* hram = H(R,A,m) */
+    ed25519_hram(hash, RS, pk, m, mlen, hashTf);
     expand256_modm(hram, hash, 64);
 
     /* S */
@@ -1798,15 +1986,58 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
 }
 
 int
+ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64],
+                      HashTransformation& hashTf)
+{
+    using namespace CryptoPP::Donna::Ed25519;
+
+    ALIGN(ALIGN_SPEC) ge25519 R, A;
+    hash_512bits hash;
+    bignum256modm hram, S;
+    byte checkR[32];
+
+    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+        return -1;
+
+    /* hram = H(R,A,m) */
+    ed25519_hram(hash, RS, pk, stream, hashTf);
+    expand256_modm(hram, hash, 64);
+
+    /* S */
+    expand256_modm(S, RS + 32, 32);
+
+    /* SB - H(R,A,m)A */
+    ge25519_double_scalarmult_vartime(&R, &A, hram, S);
+    ge25519_pack(checkR, &R);
+
+    /* check that R = SB - H(R,A,m)A */
+    return ed25519_verify(RS, checkR, 32) ? 0 : -1;
+}
+
+int
 ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64])
 {
     return ed25519_sign_open_CXX(stream, publicKey, signature);
 }
 
 int
+ed25519_sign_open(std::istream& stream, const byte publicKey[32], const byte signature[64],
+                  HashTransformation& hash)
+{
+    return ed25519_sign_open_CXX(stream, publicKey, signature, hash);
+}
+
+int
 ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKey[32], const byte signature[64])
 {
     return ed25519_sign_open_CXX(message, messageLength, publicKey, signature);
+}
+
+int
+ed25519_sign_open(const byte *message, size_t messageLength, const byte publicKey[32], const byte signature[64],
+                  HashTransformation& hash)
+{
+    return ed25519_sign_open_CXX(message, messageLength, publicKey, signature, hash);
 }
 
 NAMESPACE_END  // Donna


### PR DESCRIPTION
On the Crypto++ wiki, it says:

> ed25519 uses SHA512 as the hash. It is hard wired into the source files and there is no way to change it without recompiling sources. In the future we may add overloaded functions that allow the caller to specify a `HashTransformation`.

I added a bunch of overloaded functions to `donna.h`, `donna_32.cpp`, and `donna_64.cpp` with a new parameter called `hash` (or sometimes `hashTf` where "hash" was already being used as a variable name), which is a reference to a HashTransformation derived class that the functions will use instead of SHA512. The original functions remain unchanged, so any code that uses them doesn't have to be rewritten.

I didn't add a way to specify a HashTransformation in the high level Crypto++ objects, mostly cause I was too lazy to figure out how it works. I might try and figure it out at some point, but for now the ability to specify a HashTransformation is limited to the low level Donna functions.

I also fixed two typos in `donna.h`:

- `namespace and are curve25519_mult()` -> `namespace are curve25519_mult()`
- `<tt>pubkey</tt>` -> `<tt>publicKey</tt>`

The comments stating "At the moment the hash function for signing is fixed at SHA512." have been removed as well.