### PR TITLE
Load msvcrt explicitly when not loaded

### DIFF
--- a/dll.cpp
+++ b/dll.cpp
@@ -119,8 +119,11 @@ static void SetNewAndDeleteFunctionPointers()
 	// try getting these directly using mangled names of new and delete operators
 
 	hModule = GetModuleHandle("msvcrtd");
-	if (!hModule)
+	if (!hModule) 
 		hModule = GetModuleHandle("msvcrt");
+	if (!hModule)
+		hModule = LoadLibrary("msvcrt.dll");
+	
 	if (hModule)
 	{
 		// 32-bit versions
@@ -135,7 +138,7 @@ static void SetNewAndDeleteFunctionPointers()
 		if (s_pNew && s_pDelete)
 			return;
 	}
-
+		
 	OutputDebugStringA("Crypto++ DLL was not able to obtain new and delete function pointers.\n");
 	throw 0;
 }


### PR DESCRIPTION
EVE Online started shipping with the cryptopp DLL recently, which was crashing when being ran with Wine on Linux. After a bunch of debugging, I found out that `dll.cpp` was assuming `msvcrt.dll` was already loaded, which failed since the wine system binaries are not linked with msvcrt (only `ucrtbase` as of wine 5.9). This patch loads `msvcrt.dll` if module handles aren't found for `msvcrt` and `msvcrtd` before attempting to set the pointers.