### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ local.properties
 *.suo
 *.user
 *.sdf
+/.vs
 
 # Build results
 


### PR DESCRIPTION
This ignores the .vs directory at the root. This is used by Visual Studio to save user configuration that should not be in source control.