### PR TITLE
Try fix ProcessData in CFB_CipherTemplate and AdditiveCipherTemplate

### DIFF
--- a/misc.cpp
+++ b/misc.cpp
@@ -35,7 +35,7 @@
 #  include <immintrin.h>
 # endif
 
-# if defined(__aarch64__) || defined(__aarch32__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
 #  if (CRYPTOPP_ARM_NEON_HEADER) || (CRYPTOPP_ARM_ASIMD_AVAILABLE)
 #   include <arm_neon.h>
 #  endif

--- a/strciphr.h
+++ b/strciphr.h
@@ -394,8 +394,7 @@ protected:
 	inline byte * KeystreamBufferBegin() {return this->m_buffer.data();}
 	inline byte * KeystreamBufferEnd() {return (PtrAdd(this->m_buffer.data(), this->m_buffer.size()));}
 
-	// m_tempOutString added due to GH #1010
-	AlignedSecByteBlock m_buffer, m_tempOutString;
+	AlignedSecByteBlock m_buffer;
 	size_t m_leftOver;
 };
 
@@ -646,8 +645,6 @@ protected:
 
 	void UncheckedSetKey(const byte *key, unsigned int length, const NameValuePairs &params);
 
-	// m_tempOutString added due to GH #1010
-	AlignedSecByteBlock m_tempOutString;
 	size_t m_leftOver;
 };
 


### PR DESCRIPTION
This commit attempts to restore performance while taming the optimizer.

Also see GH #683, GH #1010, GH #1088, GH #1103.