### PR TITLE
Remove obsolete workarounds for #649 and #735

### DIFF
--- a/chacha_avx.cpp
+++ b/chacha_avx.cpp
@@ -36,13 +36,12 @@ extern const char CHACHA_AVX_FNAME[] = __FILE__;
 # define MAYBE_CONST const
 #endif
 
-// VS2017 and global optimization bug. TODO, figure out when
-// we can re-enable full optimizations for VS2017. Also see
+// VS2017 and global optimization bug. Also see
 // https://github.com/weidai11/cryptopp/issues/649 and
 // https://github.com/weidai11/cryptopp/issues/735. The
 // 649 issue affects AES but it is the same here. The 735
 // issue is ChaCha AVX2 cut-in where it surfaced again.
-#if (_MSC_VER >= 1910)
+#if (_MSC_VER >= 1910) && (_MSC_VER < 1916)
 # ifndef CRYPTOPP_DEBUG
 #  pragma optimize("", off)
 #  pragma optimize("ts", on)

--- a/rijndael.cpp
+++ b/rijndael.cpp
@@ -88,10 +88,9 @@ being unloaded from L1 cache, until that round is finished.
 #include "misc.h"
 #include "cpu.h"
 
-// VS2017 and global optimization bug. TODO, figure out when
-// we can re-enable full optimizations for VS2017. Also see
+// VS2017 and global optimization bug. Also see
 // https://github.com/weidai11/cryptopp/issues/649
-#if (_MSC_VER >= 1910)
+#if (_MSC_VER >= 1910) && (_MSC_VER < 1916)
 # ifndef CRYPTOPP_DEBUG
 #  pragma optimize("", off)
 #  pragma optimize("ts", on)


### PR DESCRIPTION
This removes the MSVC-specific workarounds added as part of #649 and #735. I tested with both the latest version of VS 2017 and VS2022 and could not reproduce the bug (I hardcoded the flag `g_hasAESNI` to false, built in Release mode, and ran the tests via `cryptest v`, as suggested in #649).

The workaround that had previously been applied leads to a massive slowdown of ChaCha, to a point where even the SSE2 version is much faster than the AVX2 implementation (so instead of disabling optimizations for AVX2, disabling the AVX2 variant altogether and falling back to SSE2 would have been the better workaround):

Before:

<img width="573" alt="image" src="https://user-images.githubusercontent.com/15180557/178360241-7f52e260-1fa2-4c3c-a003-5415f7f2b5aa.png">

After, with optimizations enabled:

<img width="494" alt="image" src="https://user-images.githubusercontent.com/15180557/178360664-d33c4857-61fa-4e55-8285-8aa182bf48ad.png">
