### PR TITLE
Disable global optimizations for all versions of VS2017 (GH #649, GH #735)

### DIFF
--- a/chacha_avx.cpp
+++ b/chacha_avx.cpp
@@ -41,7 +41,7 @@ extern const char CHACHA_AVX_FNAME[] = __FILE__;
 // https://github.com/weidai11/cryptopp/issues/735. The
 // 649 issue affects AES but it is the same here. The 735
 // issue is ChaCha AVX2 cut-in where it surfaced again.
-#if (_MSC_VER >= 1910) && (_MSC_VER < 1916)
+#if (_MSC_VER >= 1910) && (_MSC_VER <= 1916)
 # ifndef CRYPTOPP_DEBUG
 #  pragma optimize("", off)
 #  pragma optimize("ts", on)

--- a/rijndael.cpp
+++ b/rijndael.cpp
@@ -90,7 +90,7 @@ being unloaded from L1 cache, until that round is finished.
 
 // VS2017 and global optimization bug. Also see
 // https://github.com/weidai11/cryptopp/issues/649
-#if (_MSC_VER >= 1910) && (_MSC_VER < 1916)
+#if (_MSC_VER >= 1910) && (_MSC_VER <= 1916)
 # ifndef CRYPTOPP_DEBUG
 #  pragma optimize("", off)
 #  pragma optimize("ts", on)


### PR DESCRIPTION
We started seeing failed self test under VS2017 on AppVeyor. See https://ci.appveyor.com/project/noloader/cryptopp/builds/44570276 .