### PR TITLE
Add -fno-devirtualize when using GCC 12 (GH #1134, GH #1141)

### DIFF
--- a/Filelist.txt
+++ b/Filelist.txt
@@ -608,12 +608,12 @@ TestPrograms/test_cxx11_auto.cpp
 TestPrograms/test_cxx11_constexpr.cpp
 TestPrograms/test_cxx11.cpp
 TestPrograms/test_cxx11_deletefn.cpp
-TestPrograms/test_cxx11_staticinit.cpp
 TestPrograms/test_cxx11_enumtype.cpp
 TestPrograms/test_cxx11_initializer.cpp
 TestPrograms/test_cxx11_lambda.cpp
 TestPrograms/test_cxx11_noexcept.cpp
 TestPrograms/test_cxx11_nullptr.cpp
+TestPrograms/test_cxx11_staticinit.cpp
 TestPrograms/test_cxx11_sync.cpp
 TestPrograms/test_cxx11_vartemplates.cpp
 TestPrograms/test_cxx14.cpp
@@ -624,6 +624,7 @@ TestPrograms/test_cxx98_exception.cpp
 TestPrograms/test_cxx.cpp
 TestPrograms/test_glibc.cpp
 TestPrograms/test_newlib.cpp
+TestPrograms/test_nodevirtualize.cpp
 TestPrograms/test_ppc_aes.cpp
 TestPrograms/test_ppc_altivec.cpp
 TestPrograms/test_ppc_power7.cpp

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -846,6 +846,18 @@ ifeq ($(IS_X86)$(IS_CYGWIN)$(IS_MINGW),000)
   endif
 endif
 
+# Fix for GH #1134 and GH #1141. We need to add -fno-devirtualize because GCC is removing
+# code we are using. https://github.com/weidai11/cryptopp/issues/1134 and
+# https://github.com/weidai11/cryptopp/issues/1141
+ifeq ($(findstring -fno-devirtualize,$(CXXFLAGS)),)
+   TPROG = TestPrograms/test_nodevirtualize.cpp
+   TOPT = -fno-devirtualize
+   HAVE_OPT = $(shell $(TCOMMAND) 2>&1 | wc -w)
+   ifeq ($(strip $(HAVE_OPT)),0)
+      CRYPTOPP_CXXFLAGS += -fno-devirtualize
+   endif # CRYPTOPP_CXXFLAGS
+endif # -fno-devirtualize
+
 # Use -pthread whenever it is available. See http://www.hpl.hp.com/techreports/2004/HPL-2004-209.pdf
 #   http://stackoverflow.com/questions/2127797/gcc-significance-of-pthread-flag-when-compiling
 ifeq ($(DETECT_FEATURES),1)
@@ -857,7 +869,7 @@ ifeq ($(DETECT_FEATURES),1)
    ifeq ($(strip $(HAVE_OPT)),0)
     CRYPTOPP_CXXFLAGS += -qthreaded
    endif # CRYPTOPP_CXXFLAGS
-  endif # qthreaded
+  endif # -qthreaded
  else
   ifeq ($(findstring -pthread,$(CXXFLAGS)),)
    TPROG = TestPrograms/test_pthreads.cpp
@@ -866,7 +878,7 @@ ifeq ($(DETECT_FEATURES),1)
    ifeq ($(strip $(HAVE_OPT)),0)
     CRYPTOPP_CXXFLAGS += -pthread
    endif  # CRYPTOPP_CXXFLAGS
-  endif  # pthread
+  endif  # -pthread
  endif  # XLC/GCC and friends
 endif  # DETECT_FEATURES
 

--- a/TestPrograms/test_nodevirtualize.cpp
+++ b/TestPrograms/test_nodevirtualize.cpp
@@ -1,0 +1,19 @@
+#include <string>
+
+// https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+int main(int argc, char* argv[])
+{
+    // GCC 12 is removing live code. We don't know why.
+    // https://github.com/weidai11/cryptopp/issues/1134 and
+    // https://github.com/weidai11/cryptopp/issues/1141
+#if defined(__linux__) && (GCC_VERSION >= 120000)
+    // On successful compile -fno-devirtualize will be used
+    // to work around the problem.
+    ;;
+#else
+    int x[-1];
+#endif
+    return 0;
+}

--- a/test.cpp
+++ b/test.cpp
@@ -398,7 +398,10 @@ int scoped_main(int argc, char *argv[])
 		else if (command == "ir")
 			InformationRecoverFile(argc-3, argv[2], argv+3);
 		else if (command == "v" || command == "vv")
-			return !Validate(argc>2 ? StringToValue<int, true>(argv[2]) : 0, command == "vv" /*thorough*/);
+		{
+			int testNumber = argc>2 ? StringToValue<int, true>(argv[2]) : 0;
+			return Validate(testNumber, command == "vv" /*thorough*/) ? 0 : 1;
+        }
 		else if (command.substr(0,1) == "b") // "b", "b1", "b2", ...
 			BenchmarkWithCommand(argc, argv);
 		else if (command == "z")

--- a/validat9.cpp
+++ b/validat9.cpp
@@ -652,20 +652,17 @@ bool ValidateECGDSA(bool thorough)
 {
 	std::cout << "\nECGDSA validation suite running...\n\n";
 
-	// 'thorough' forced to false due to GH #1134. There is something sideways
-	// with GCC 12 and ECGDSA+RIPEMD. The problem is present with
-	// CRYPTOPP_DISABLE_ASM, which indicates a C++ problem. However, Asan,
-	// UBsan and Valgrind fail to produce a finding. The program simply crashes
-	// with a junk backtrace. And GCC 11 (and earlier), Clang, MSVC, xlC are Ok.
-	// This is likely a compiler bug.
-#if CRYPTOPP_GCC_VERSION >= 120000
-	thorough = false;
-#endif
+	bool pass = true, fail;
 
-	if (thorough)
-		return ValidateECGDSAStandard() && ValidateECGDSAThorough();
-	else
-		return ValidateECGDSAStandard();
+	fail = !ValidateECGDSAStandard();
+	pass = pass && !fail;
+
+	if (thorough) {
+		fail = !ValidateECGDSAThorough();
+		pass = pass && !fail;
+	}
+
+	return pass;
 }
 
 bool ValidateESIGN()


### PR DESCRIPTION
This is not a fix since it only treats the symptom of GCC removing live code. We do not know why GCC is doing it.