### PR TITLE
Add Visual Studio 2022 to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,7 @@ platform:
 
 image:
 
+- Visual Studio 2022
 - Visual Studio 2019
 - Visual Studio 2017
 - Visual Studio 2015


### PR DESCRIPTION
This adds Visual Studio 2022 builds to AppVeyor CI. I've already checked in my own fork that these run through successfully.