### PR TITLE
Enable crc instructions when building for arm64 cpu (iOS)

### DIFF
--- a/TestScripts/setenv-ios.sh
+++ b/TestScripts/setenv-ios.sh
@@ -91,6 +91,7 @@ unset IOS_CFLAGS
 unset IOS_CXXFLAGS
 unset IOS_LDFLAGS
 unset IOS_SYSROOT
+unset CRC
 
 #########################################
 #####    Small Fixups, if needed    #####
@@ -133,6 +134,7 @@ fi
 
 if [[ "${IOS_CPU}" == "aarch64" || "${IOS_CPU}" == "arm64"* || "${IOS_CPU}" == "armv8"* ]] ; then
     IOS_CPU=arm64
+    CRC="-mcrc"
 fi
 
 echo "Configuring for ${IOS_SDK} (${IOS_CPU})"
@@ -282,7 +284,7 @@ if [ -z "${XCODE_SDK}" ]; then
 fi
 
 IOS_CFLAGS="-arch ${IOS_CPU} ${MIN_VER} -fno-common"
-IOS_CXXFLAGS="-arch ${IOS_CPU} ${MIN_VER} -stdlib=libc++ -fno-common"
+IOS_CXXFLAGS="-arch ${IOS_CPU} ${CRC} ${MIN_VER} -stdlib=libc++ -fno-common"
 IOS_SYSROOT="${XCODE_DEVELOPER_SDK}/${XCODE_SDK}"
 
 if [ ! -d "${IOS_SYSROOT}" ]; then


### PR DESCRIPTION
I am not sure if this is the correct way to fix the compilation issue https://github.com/weidai11/cryptopp/issues/1074, but this works for me.

CRC instructions are enabled by default on ARMv8, but I don't know why it doesn't work when building for arm64, so I have added `mcrc` to `IOS_CXXFLAGS` if the CPU is arm64


> **-m[no-]crc**
> Enable or disable CRC instructions.
> 
> This option is used to indicate whether CRC instructions are to be generated. This only applies to the ARM architecture.
> 
> CRC instructions are enabled by default on ARMv8.
> 

https://clang.llvm.org/docs/UsersManual.html