### PR TITLE
std::swap should not throw for C++11

### DIFF
--- a/queue.h
+++ b/queue.h
@@ -262,7 +262,7 @@ NAMESPACE_END
 
 #ifndef __BORLANDC__
 NAMESPACE_BEGIN(std)
-template<> inline void swap(CryptoPP::ByteQueue &a, CryptoPP::ByteQueue &b)
+template<> inline void swap(CryptoPP::ByteQueue &a, CryptoPP::ByteQueue &b) CRYPTOPP_NO_THROW
 {
 	a.swap(b);
 }


### PR DESCRIPTION
Adding noexcept with the macro CRYPTOPP_NO_THROW