### PR TITLE
Uninitialized member variable with macro

### DIFF
--- a/config_cxx.h
+++ b/config_cxx.h
@@ -237,6 +237,13 @@
 #  define CRYPTOPP_NO_THROW
 #endif // CRYPTOPP_CXX11_NOEXCEPT
 
+
+#if defined(CRYPTOPP_CXX11_INITIALIZER_LIST)
+#  define CRYPTOPP_DEFAULT_INIT = {}
+#else
+#  define CRYPTOPP_DEFAULT_INIT
+#endif // CRYPTOPP_CXX11_INITIALIZER_LIST
+
 // Hack... C++11 nullptr_t type safety and analysis
 #if defined(CRYPTOPP_CXX11_NULLPTR) && !defined(NULLPTR)
 # define NULLPTR nullptr

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -2373,7 +2373,7 @@ private:
 	// for ChannelPutWord16, ChannelPutWord32 and ChannelPutWord64,
 	// to ensure the buffer isn't deallocated before non-blocking
 	// operation completes
-	byte m_buf[8];
+	byte m_buf[8] = {};
 };
 
 /// \brief An input discarding BufferedTransformation

--- a/cryptlib.h
+++ b/cryptlib.h
@@ -2373,7 +2373,7 @@ private:
 	// for ChannelPutWord16, ChannelPutWord32 and ChannelPutWord64,
 	// to ensure the buffer isn't deallocated before non-blocking
 	// operation completes
-	byte m_buf[8] = {};
+	byte m_buf[8] CRYPTOPP_DEFAULT_INIT;
 };
 
 /// \brief An input discarding BufferedTransformation


### PR DESCRIPTION
See Pull request #1172.
Using a macro solve the issue of compatibility.