### PR TITLE
Fix linker errors unresolved symbols by explicitly instantiating templates

### DIFF
--- a/algebra.cpp
+++ b/algebra.cpp
@@ -336,6 +336,9 @@ void AbstractRing<T>::SimultaneousExponentiate(T *results, const T &base, const 
 	MultiplicativeGroup().AbstractGroup<T>::SimultaneousMultiply(results, base, exponents, expCount);
 }
 
+template class AbstractRing<Integer>;
+template class AbstractGroup<Integer>;
+template class AbstractEuclideanDomain<Integer>;
 NAMESPACE_END
 
 #endif

--- a/algparam.cpp
+++ b/algparam.cpp
@@ -70,6 +70,10 @@ bool AlgorithmParameters::GetVoidValue(const char *name, const std::type_info &v
 		return false;
 }
 
+template class AlgorithmParametersTemplate<bool>;
+template class AlgorithmParametersTemplate<int>;
+template class AlgorithmParametersTemplate<ConstByteArrayParameter>;
+
 NAMESPACE_END
 
 #endif


### PR DESCRIPTION
When building a shared library with C++17 linker fails with numerous errors about unresolved symbols - template vtables and methods. This PR adds explicit template instantiation to let the compiler generating them.