### PR TITLE
Fix macro and member function confilct for min and max

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -783,7 +783,7 @@ inline bool SafeConvert(sword32 from, word64 &to)
 template<>
 inline bool SafeConvert(word64 from, sword64 &to)
 {
-	if (from > static_cast<word64>(std::numeric_limits<sword64>::max()))
+	if (from > static_cast<word64>((std::numeric_limits<sword64>::max)()))
 		return false;
 	to = static_cast<sword64>(from);
 	return true;
@@ -827,7 +827,7 @@ inline bool SafeConvert(sword32 from, sword64 &to)
 template<>
 inline bool SafeConvert(word64 from, word32 &to)
 {
-	if (from > static_cast<word64>(std::numeric_limits<word32>::max()))
+	if (from > static_cast<word64>((std::numeric_limits<word32>::max)()))
 		return false;
 	to = static_cast<word32>(from);
 	return true;
@@ -845,7 +845,7 @@ inline bool SafeConvert(sword64 from, word32 &to)
 {
 	if (from < 0)
 		return false;
-	else if (from > static_cast<sword64>(std::numeric_limits<word32>::max()))
+	else if (from > static_cast<sword64>((std::numeric_limits<word32>::max)()))
 		return false;
 	to = static_cast<word32>(from);
 	return true;
@@ -877,7 +877,7 @@ inline bool SafeConvert(sword32 from, word32 &to)
 template<>
 inline bool SafeConvert(word64 from, sword32 &to)
 {
-	if (from > static_cast<word64>(std::numeric_limits<sword32>::max()))
+	if (from > static_cast<word64>((std::numeric_limits<sword32>::max)()))
 		return false;
 	to = static_cast<sword32>(from);
 	return true;
@@ -893,9 +893,9 @@ inline bool SafeConvert(word64 from, sword32 &to)
 template<>
 inline bool SafeConvert(sword64 from, sword32 &to)
 {
-	if (from > static_cast<sword64>(std::numeric_limits<sword32>::max()))
+	if (from > static_cast<sword64>((std::numeric_limits<sword32>::max)()))
 		return false;
-	else if (from < static_cast<sword64>(std::numeric_limits<sword32>::min()))
+	else if (from < static_cast<sword64>((std::numeric_limits<sword32>::min)()))
 		return false;
 	to = static_cast<sword32>(from);
 	return true;
@@ -911,7 +911,7 @@ inline bool SafeConvert(sword64 from, sword32 &to)
 template<>
 inline bool SafeConvert(word32 from, sword32 &to)
 {
-	if (from > static_cast<word32>(std::numeric_limits<sword32>::max()))
+	if (from > static_cast<word32>((std::numeric_limits<sword32>::max)()))
 		return false;
 	to = static_cast<sword32>(from);
 	return true;


### PR DESCRIPTION
The library builds fine in VS 2022, but compilation of a Windows application ends up with thousads of errors.
The reason is that several MS C++ headers define `min` and `max` as macros.
An example of preprocessed code:
`if (from > static_cast<word64>(std::numeric_limits<sword64>::((() > ()) ? () : ())))`

Quick search in the net gave [this hint](https://stackoverflow.com/questions/1394132/macro-and-member-function-conflict) to add parentheses and prevent macro expansion.