### PR TITLE
Fix unused parameter warnings for x86 non-GCC

### DIFF
--- a/sha.cpp
+++ b/sha.cpp
@@ -835,6 +835,9 @@ INTEL_NOPREFIX
         , "%ebx"
     #endif
     );
+#else
+    CRYPTOPP_UNUSED(state);
+    CRYPTOPP_UNUSED(data);
 #endif
 }
 
@@ -1303,6 +1306,8 @@ void CRYPTOPP_FASTCALL SHA512_HashBlock_SSE2(word64 *state, const word64 *data)
 #endif
     );
 #else
+    CRYPTOPP_UNUSED(state);
+    CRYPTOPP_UNUSED(data);
     AS1(    pop        edi)
     AS1(    pop        esi)
     AS1(    pop        ebx)


### PR DESCRIPTION
These were suppressed for MSVC until commit dced966b7ac.