### PR TITLE
Validate p in ModularSquareRoot

### DIFF
--- a/nbtheory.cpp
+++ b/nbtheory.cpp
@@ -543,6 +543,9 @@ Integer CRT(const Integer &xp, const Integer &p, const Integer &xq, const Intege
 
 Integer ModularSquareRoot(const Integer &a, const Integer &p)
 {
+	if (!IsPrime(p))
+		throw InvalidArgument("ModularSquareRoot: p must be a prime");
+
 	if (p%4 == 3)
 		return a_exp_b_mod_c(a, (p+1)/4, p);
 


### PR DESCRIPTION
This fix [issue#1249](https://github.com/weidai11/cryptopp/issues/1249)