### PR TITLE
Fix build for Windows ARM64EC

### DIFF
--- a/config_asm.h
+++ b/config_asm.h
@@ -252,7 +252,7 @@
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
 #if !defined(CRYPTOPP_ARM_ASIMD_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_ASIMD)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_NEON) || defined(__ARM_ASIMD) || defined(__ARM_FEATURE_NEON) || defined(__ARM_FEATURE_ASIMD) || \
       (CRYPTOPP_GCC_VERSION >= 40800) || (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || \
       (CRYPTOPP_APPLE_CLANG_VERSION >= 40000) || (CRYPTOPP_MSC_VERSION >= 1916)
@@ -265,7 +265,7 @@
 // ARMv8 and ASIMD. -march=armv8-a+crc or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 #if !defined(CRYPTOPP_ARM_CRC32_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_CRC32)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_CRC32) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300) || \
       (CRYPTOPP_MSC_VERSION >= 1916)
@@ -277,7 +277,7 @@
 // ARMv8 and AES. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 #if !defined(CRYPTOPP_ARM_AES_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_AES)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300) || \
       (CRYPTOPP_MSC_VERSION >= 1916)
@@ -289,7 +289,7 @@
 // ARMv8 and PMULL. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 #if !defined(CRYPTOPP_ARM_PMULL_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_PMULL)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300) || \
       (CRYPTOPP_MSC_VERSION >= 1916)
@@ -301,7 +301,7 @@
 // ARMv8 and SHA-1, SHA-256. -march=armv8-a+crypto or above must be present
 // Requires GCC 4.8, Clang 3.3 or Visual Studio 2017
 #if !defined(CRYPTOPP_ARM_SHA_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SHA)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_CRYPTO) || (CRYPTOPP_GCC_VERSION >= 40800) || \
       (CRYPTOPP_LLVM_CLANG_VERSION >= 30300) || (CRYPTOPP_APPLE_CLANG_VERSION >= 40300) || \
       (CRYPTOPP_MSC_VERSION >= 1916)
@@ -320,7 +320,7 @@
 // ARMv8 and SHA-512, SHA-3. -march=armv8.2-a+crypto or above must be present
 // Requires GCC 8.0, Clang 11.0, Apple Clang 12.0 or Visual Studio 20??
 #if !defined(CRYPTOPP_ARM_SHA3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SHA)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_SHA3) || (CRYPTOPP_GCC_VERSION >= 80000) || \
       (CRYPTOPP_APPLE_CLANG_VERSION >= 120000) || (CRYPTOPP_LLVM_CLANG_VERSION >= 110000)
 #   define CRYPTOPP_ARM_SHA512_AVAILABLE 1
@@ -333,7 +333,7 @@
 // Requires GCC 8.0, Clang ??? or Visual Studio 20??
 // Do not use APPLE_CLANG_VERSION; use __ARM_FEATURE_XXX instead.
 #if !defined(CRYPTOPP_ARM_SM3_AVAILABLE) && !defined(CRYPTOPP_DISABLE_ARM_SM3)
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if defined(__ARM_FEATURE_SM3) || (CRYPTOPP_GCC_VERSION >= 80000)
 #   define CRYPTOPP_ARM_SM3_AVAILABLE 1
 #   define CRYPTOPP_ARM_SM4_AVAILABLE 1
@@ -344,7 +344,7 @@
 // Limit the <arm_neon.h> include.
 #if !defined(CRYPTOPP_ARM_NEON_HEADER)
 # if defined(CRYPTOPP_ARM_NEON_AVAILABLE) || defined (CRYPTOPP_ARM_ASIMD_AVAILABLE)
-#  if !defined(_M_ARM64)
+#  if !defined(_M_ARM64) &&!defined(_M_ARM64EC)
 #   define CRYPTOPP_ARM_NEON_HEADER 1
 #  endif
 # endif

--- a/config_cpu.h
+++ b/config_cpu.h
@@ -52,7 +52,7 @@
 	#define CRYPTOPP_BOOL_X86 ...
 #elif (defined(__ILP32__) || defined(_ILP32)) && defined(__x86_64__)
 	#define CRYPTOPP_BOOL_X32 1
-#elif (defined(_M_X64) || defined(__x86_64__))
+#elif ((defined(_M_X64) && !defined(_M_ARM64EC)) || defined(__x86_64__))
 	#define CRYPTOPP_BOOL_X64 1
 #elif (defined(_M_IX86) || defined(__i386__) || defined(__i386) || defined(_X86_) || defined(__I86__) || defined(__INTEL__))
 	#define CRYPTOPP_BOOL_X86 1
@@ -79,7 +79,7 @@
 	// Microsoft added ARM64 define December 2017.
 	#define CRYPTOPP_BOOL_ARMV8 1
 #endif
-#if defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	#define CRYPTOPP_BOOL_ARM64 1
 #elif defined(__arm__) || defined(_M_ARM)
 	#define CRYPTOPP_BOOL_ARM32 1

--- a/cpu.cpp
+++ b/cpu.cpp
@@ -22,7 +22,7 @@
 
 // For IsProcessorFeaturePresent on Microsoft Arm64 platforms,
 // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
-#if defined(_WIN32) && defined(_M_ARM64)
+#if defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 # include <Windows.h>
 # include <processthreadsapi.h>
 #endif
@@ -854,7 +854,7 @@ inline bool CPU_QueryARMv7()
 #elif defined(__APPLE__) && defined(__arm__)
 	// Apple hardware is ARMv7 or above.
 	return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	// Windows 10 ARM64 is only supported on Armv8a and above
 	return true;
 #endif
@@ -884,7 +884,7 @@ inline bool CPU_QueryNEON()
 	// Core feature set for Aarch32 and Aarch64.
 	if (IsAppleMachineARMv8())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	// Windows 10 ARM64 is only supported on Armv8a and above
 	if (IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
@@ -912,7 +912,7 @@ inline bool CPU_QueryCRC32()
 	// M1 processor
 	if (IsAppleMachineARMv82())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
 #endif
@@ -939,7 +939,7 @@ inline bool CPU_QueryPMULL()
 	// M1 processor
 	if (IsAppleMachineARMv82())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
 #endif
@@ -966,7 +966,7 @@ inline bool CPU_QueryAES()
 	// M1 processor
 	if (IsAppleMachineARMv82())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
 #endif
@@ -993,7 +993,7 @@ inline bool CPU_QuerySHA1()
 	// M1 processor
 	if (IsAppleMachineARMv82())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
 #endif
@@ -1020,7 +1020,7 @@ inline bool CPU_QuerySHA256()
 	// M1 processor
 	if (IsAppleMachineARMv82())
 		return true;
-#elif defined(_WIN32) && defined(_M_ARM64)
+#elif defined(_WIN32) && (defined(_M_ARM64) || defined(_M_ARM64EC))
 	if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) != 0)
 		return true;
 #endif

--- a/donna_64.h
+++ b/donna_64.h
@@ -16,8 +16,12 @@
 
 #if defined(CRYPTOPP_MSC_VERSION)
 # include <intrin.h>
-# pragma intrinsic(_umul128)
-# pragma intrinsic(__shiftright128)
+# ifndef _M_ARM64EC
+#  pragma intrinsic(_umul128)
+#  pragma intrinsic(__shiftright128)
+# else
+#  include <minwindef.h>
+# endif
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)

--- a/integer.cpp
+++ b/integer.cpp
@@ -76,6 +76,9 @@
 #include <iostream>
 
 #if (CRYPTOPP_MSC_VERSION >= 1400) && !defined(_M_ARM)
+	#ifdef _M_ARM64EC
+		#include <minwindef.h> // __shiftleft128
+	#endif
 	#include <intrin.h>
 #endif
 

--- a/lea_simd.cpp
+++ b/lea_simd.cpp
@@ -39,7 +39,7 @@
 # include <arm_acle.h>
 #endif
 
-#if defined(_M_ARM64)
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
 # include "adv_simd.h"
 #endif
 

--- a/misc.cpp
+++ b/misc.cpp
@@ -35,7 +35,7 @@
 #  include <immintrin.h>
 # endif
 
-# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+# if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 #  if (CRYPTOPP_ARM_NEON_HEADER) || (CRYPTOPP_ARM_ASIMD_AVAILABLE)
 #   include <arm_neon.h>
 #  endif
@@ -96,7 +96,7 @@ void xorbuf(byte *buf, const byte *mask, size_t count)
 		buf += 16; mask += 16; count -= 16;
 	}
 # endif
-# if defined(__aarch64__) || defined(__aarch32__) || defined(_M_ARM64)
+# if defined(__aarch64__) || defined(__aarch32__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	while (count >= 16)
 	{
 		vst1q_u8(buf, veorq_u8(vld1q_u8(buf), vld1q_u8(mask)));
@@ -170,7 +170,7 @@ void xorbuf(byte *output, const byte *input, const byte *mask, size_t count)
 		output += 16; input += 16; mask += 16; count -= 16;
 	}
 # endif
-# if defined(__aarch64__) || defined(__aarch32__) || defined(_M_ARM64)
+# if defined(__aarch64__) || defined(__aarch32__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	while (count >= 16)
 	{
 		vst1q_u8(output, veorq_u8(vld1q_u8(input), vld1q_u8(mask)));

--- a/neon_simd.cpp
+++ b/neon_simd.cpp
@@ -49,7 +49,7 @@ extern "C" {
 
 bool CPU_ProbeARMv7()
 {
-#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
     return false;
 #elif defined(CRYPTOPP_NO_CPU_FEATURE_PROBES)
     return false;
@@ -132,7 +132,7 @@ bool CPU_ProbeARMv7()
 
 bool CPU_ProbeNEON()
 {
-#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
     return true;
 #elif defined(CRYPTOPP_NO_CPU_FEATURE_PROBES)
     return false;

--- a/rijndael_simd.cpp
+++ b/rijndael_simd.cpp
@@ -43,7 +43,7 @@
 # endif
 #endif
 
-#if defined(_M_ARM64)
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
 # include "adv_simd.h"
 #endif
 

--- a/simon128_simd.cpp
+++ b/simon128_simd.cpp
@@ -39,7 +39,7 @@
 # include <arm_acle.h>
 #endif
 
-#if defined(_M_ARM64)
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
 # include "adv_simd.h"
 #endif
 
@@ -63,7 +63,7 @@ using CryptoPP::vec_swap;  // SunCC
 #if (CRYPTOPP_ARM_NEON_AVAILABLE)
 
 // Missing from Microsoft's ARM A-32 implementation
-#if defined(CRYPTOPP_MSC_VERSION) && !defined(_M_ARM64)
+#if defined(CRYPTOPP_MSC_VERSION) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
 inline uint64x2_t vld1q_dup_u64(const uint64_t* ptr)
 {
     return vmovq_n_u64(*ptr);

--- a/speck128_simd.cpp
+++ b/speck128_simd.cpp
@@ -39,7 +39,7 @@
 # include <arm_acle.h>
 #endif
 
-#if defined(_M_ARM64)
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
 # include "adv_simd.h"
 #endif
 
@@ -62,7 +62,7 @@ using CryptoPP::word64;
 #if (CRYPTOPP_ARM_NEON_AVAILABLE)
 
 // Missing from Microsoft's ARM A-32 implementation
-#if defined(CRYPTOPP_MSC_VERSION) && !defined(_M_ARM64)
+#if defined(CRYPTOPP_MSC_VERSION) && !defined(_M_ARM64) && !defined(_M_ARM64EC)
 inline uint64x2_t vld1q_dup_u64(const uint64_t* ptr)
 {
     return vmovq_n_u64(*ptr);

--- a/xts.cpp
+++ b/xts.cpp
@@ -24,7 +24,7 @@
 # include <emmintrin.h>
 #endif
 
-#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 # if (CRYPTOPP_ARM_NEON_HEADER) || (CRYPTOPP_ARM_ASIMD_AVAILABLE)
 #  include <arm_neon.h>
 # endif
@@ -65,14 +65,14 @@ inline void XorBuffer(byte *output, const byte *input, const byte *mask, size_t 
 #if defined(CRYPTOPP_DISABLE_ASM)
     xorbuf(output, input, mask, count);
 
-#elif defined(__SSE2__) || defined(_M_X64)
+#elif defined(__SSE2__) || (defined(_M_X64) && !defined(_M_ARM64EC))
     for (size_t i=0; i<count; i+=16)
         _mm_storeu_si128(M128_CAST(output+i),
             _mm_xor_si128(
                 _mm_loadu_si128(CONST_M128_CAST(input+i)),
                 _mm_loadu_si128(CONST_M128_CAST(mask+i))));
 
-#elif defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
     for (size_t i=0; i<count; i+=16)
         vst1q_u8(output+i, veorq_u8(vld1q_u8(input+i), vld1q_u8(mask+i)));
 


### PR DESCRIPTION
In MSVC, ARM64EC is a variant of the Windows ARM64 ABI that allows mixing native ARM64 code and emulated x64 code in the same process. It is useful, e.g., for programs that need to be able to load legacy x64 plugin DLLs.
When building for ARM64EC, `_M_X64` is defined and many x64 intrinsics are available for compatibility. All ARM64 intrinsics are still available and while `_M_ARM64` is not defined, `_M_ARM64EC` is.

Changes include:
- Treat presence of `_M_ARM64EC` like `_M_ARM64`. In many cases this appears to be dead code because it's ignored when `CRYPTOPP_DISABLE_ASM` is set, which appears to be currently required for successful non-x64 Windows builds, but I've nevertheless made the changes everywhere for uniformity.
- Add inclusion of `winnt.h` (indirectly, by way of `minwindef.h`) to pick up the declarations of intrinsics like `__shiftleft128` on ARM64EC, when necessary.

For the actual build, I've used cryptopp-cmake with some tweaks for ARM64EC detection.
Verified by running the resulting ARM64EC build of `cryptest.exe v` on a Windows ARM64 device.
