### PR TITLE
Fixing an infinite loop scenario in case of memory exhaustion

### DIFF
--- a/allocate.cpp
+++ b/allocate.cpp
@@ -39,6 +39,7 @@ void CallNewHandler()
 
 void * AlignedAllocate(size_t size)
 {
+        unsigned int cnt = 0;
 	byte *p;
 #if defined(CRYPTOPP_MM_MALLOC_AVAILABLE)
 	while ((p = (byte *)_mm_malloc(size, 16)) == NULLPTR)
@@ -51,8 +52,12 @@ void * AlignedAllocate(size_t size)
 #else
 	while ((p = (byte *)malloc(size + 16)) == NULLPTR)
 #endif
-		CallNewHandler();
-
+	  {
+	    if (cnt >= 10)
+	      throw std::bad_alloc();
+	     CallNewHandler();
+	     cnt++;
+	  }
 #ifdef CRYPTOPP_NO_ALIGNED_ALLOC
 	size_t adjustment = 16-((size_t)p%16);
 	CRYPTOPP_ASSERT(adjustment > 0);


### PR DESCRIPTION
Throwing an exception after 10 attempts rather than trying to allocate indefinitely (which could be infinite)