### PR TITLE
Fix compile break when building with clang-cl

### DIFF
--- a/secblock.h
+++ b/secblock.h
@@ -270,7 +270,7 @@ public:
 	/// \details VS.NET STL enforces the policy of "All STL-compliant allocators
 	///  have to provide a template class member called rebind".
     template <class V> struct rebind { typedef AllocatorWithCleanup<V, T_Align16> other; };
-#if (CRYPTOPP_MSC_VERSION >= 1500)
+#if (_MSVC_STL_VERSION >= 143)
 	AllocatorWithCleanup() {}
 	template <class V, bool A> AllocatorWithCleanup(const AllocatorWithCleanup<V, A> &) {}
 #endif


### PR DESCRIPTION
Fix a compile break when building with Clang and the Microsoft STL