### PR TITLE
Fix compile break when building with the Microsoft STL

### DIFF
--- a/config_ver.h
+++ b/config_ver.h
@@ -89,6 +89,22 @@
 # define CRYPTOPP_MSC_VERSION (_MSC_VER)
 #endif
 
+#if defined(_MSVC_STL_VERSION) // VS2017 (14.1) and above
+# define CRYPTOPP_MSSTL_VERSION _MSVC_STL_VERSION
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 650 // VS2015 (14.0)
+# define CRYPTOPP_MSSTL_VERSION 140
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 610 // VS2013 (12.0)
+# define CRYPTOPP_MSSTL_VERSION 120
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 540 // VS2012 (11.0)
+# define CRYPTOPP_MSSTL_VERSION 110
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 520 // VS2010 (10.0)
+# define CRYPTOPP_MSSTL_VERSION 100
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 505 // VS2008SP1 (9.0)
+# define CRYPTOPP_MSSTL_VERSION 91
+#elif defined(_CPPLIB_VER) && _CPPLIB_VER >= 503 // VS2008 (also 9.0)
+# define CRYPTOPP_MSSTL_VERSION 90
+#endif
+
 // To control <x86intrin.h> include. May need a guard, like GCC 4.5 and above
 // Also see https://stackoverflow.com/a/42493893 and https://github.com/weidai11/cryptopp/issues/1198
 #if defined(CRYPTOPP_GCC_VERSION) || defined(CRYPTOPP_APPLE_CLANG_VERSION) || defined(CRYPTOPP_LLVM_CLANG_VERSION)

--- a/secblock.h
+++ b/secblock.h
@@ -269,8 +269,8 @@ public:
 	///  store elements in the list.
 	/// \details VS.NET STL enforces the policy of "All STL-compliant allocators
 	///  have to provide a template class member called rebind".
-    template <class V> struct rebind { typedef AllocatorWithCleanup<V, T_Align16> other; };
-#if (CRYPTOPP_MSC_VERSION >= 1500)
+	template <class V> struct rebind { typedef AllocatorWithCleanup<V, T_Align16> other; };
+#if (CRYPTOPP_MSSTL_VERSION >= 90)
 	AllocatorWithCleanup() {}
 	template <class V, bool A> AllocatorWithCleanup(const AllocatorWithCleanup<V, A> &) {}
 #endif


### PR DESCRIPTION
Fix a compile break when building with the Microsoft STL and a compiler other then MSVC. 

Fixed Issue: #1311