### PR TITLE
Add Zhaoxin support for RDRAND/RDSEED/ADX/SHA/AVX2 feature

### DIFF
--- a/cpu.cpp
+++ b/cpu.cpp
@@ -716,9 +716,10 @@ void DetectX86Features()
 			g_hasPadlockPMM  = (cpuid2[EDX_REG] & PMM_FLAGS) != 0;
 		}
 
-		if (extendedFeatures >= 0xC0000005)
-		{
-			CpuId(0xC0000005, 0, cpuid2);
+		CpuId(0x80000000, 0, cpuid2);
+		extendedFeatures = cpuid2[EAX_REG];
+		if (extendedFeatures >= 0x80000005) {
+			CpuId(0x80000005, 0, cpuid2);
 			g_cacheLineSize = GETBYTE(cpuid2[ECX_REG], 0);
 		}
 	}

--- a/cpu.cpp
+++ b/cpu.cpp
@@ -147,6 +147,14 @@ inline bool IsVIA(const word32 output[4])
 		(output[3] /*EDX*/ == 0x32414956));
 }
 
+inline bool IsZhaoxin(const word32 output[4])
+{
+	// This is the "  Shanghai  " string.
+	return ((output[1] /*EBX*/ == 0x68532020) &&
+		(output[2] /*ECX*/ == 0x20206961) &&
+		(output[3] /*EDX*/ == 0x68676E61));
+}
+
 #endif  // X86, X32 and X64
 
 #if defined(__APPLE__)
@@ -694,14 +702,33 @@ void DetectX86Features()
 			}
 		}
 	}
-	else if (IsVIA(cpuid0))
+	else if (IsVIA(cpuid0) || IsZhaoxin(cpuid0))
 	{
+		CRYPTOPP_CONSTANT(RDRAND_FLAG = (1 << 30));
+		CRYPTOPP_CONSTANT(RDSEED_FLAG = (1 << 18));
+		CRYPTOPP_CONSTANT(ADX_FLAG = (1 << 19));
+		CRYPTOPP_CONSTANT(SHA_FLAG = (1 << 29));
+		CRYPTOPP_CONSTANT(AVX2_FLAG = (1 << 5));
+
 		// Two bits: available and enabled
 		CRYPTOPP_CONSTANT( RNG_FLAGS = (0x3 << 2));
 		CRYPTOPP_CONSTANT( ACE_FLAGS = (0x3 << 6));
 		CRYPTOPP_CONSTANT(ACE2_FLAGS = (0x3 << 8));
 		CRYPTOPP_CONSTANT( PHE_FLAGS = (0x3 << 10));
 		CRYPTOPP_CONSTANT( PMM_FLAGS = (0x3 << 12));
+
+		g_hasRDRAND = (cpuid1[ECX_REG] & RDRAND_FLAG) != 0;
+
+		if (cpuid0[EAX_REG] >= 7)
+		{
+			if (CpuId(7, 0, cpuid2))
+			{
+				g_hasRDSEED = (cpuid2[EBX_REG] & RDSEED_FLAG) != 0;
+				g_hasADX = (cpuid2[EBX_REG] & ADX_FLAG) != 0;
+				g_hasSHA = (cpuid2[EBX_REG] & SHA_FLAG) != 0;
+				g_hasAVX2 = (cpuid2[EBX_REG] & AVX2_FLAG) != 0;
+			}
+		}
 
 		CpuId(0xC0000000, 0, cpuid2);
 		word32 extendedFeatures = cpuid2[0];


### PR DESCRIPTION
Add Zhaoxin support for RDRAND/RDSEED/ADX/SHA/AVX2 feature and fix detecting cache line size for VIA processor in cpu.cpp. 
All test passed. 