### PR TITLE
osrng: use getrandom(2) instead of /dev/random on linux/NetBSD/FreeBSD/DragonFly, open /dev/random with O_CLOEXEC

### DIFF
--- a/osrng.cpp
+++ b/osrng.cpp
@@ -259,9 +259,9 @@ void NonblockingRng::GenerateBlock(byte *output, size_t size)
 BlockingRng::BlockingRng()
 {
 #ifndef DONT_USE_O_NOFOLLOW
-	const int flags = O_RDONLY|O_NOFOLLOW;
+	const int flags = O_RDONLY|O_CLOEXEC|O_NOFOLLOW;
 #else
-	const int flags = O_RDONLY;
+	const int flags = O_RDONLY|O_CLOEXEC;
 #endif
 
 	m_fd = open(CRYPTOPP_BLOCKING_RNG_FILENAME, flags);

--- a/osrng.cpp
+++ b/osrng.cpp
@@ -76,6 +76,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/random.h>
 #endif
 
 NAMESPACE_BEGIN(CryptoPP)
@@ -302,6 +303,14 @@ void BlockingRng::GenerateBlock(byte *output, size_t size)
 
 void OS_GenerateRandomBlock(bool blocking, byte *output, size_t size)
 {
+#if __linux__ || __NetBSD__ || __FreeBSD__ || __DragonFly__
+	auto got = std::max(getrandom(output, size, blocking ? 0 : GRND_NONBLOCK), static_cast<ssize_t>(0));
+	output += got;
+	size -= got;
+#endif
+	if (size == 0)
+		return;
+
 #ifdef NONBLOCKING_RNG_AVAILABLE
 	if (blocking)
 #endif


### PR DESCRIPTION
Decays gracefully in case of errors:
```
getrandom(0x5642c460afd0, 32, 0)        = -1 ENOSYS (Function not implemented) (INJECTED)
openat(AT_FDCWD, "/dev/random", O_RDONLY) = 3
read(3, "\233\237w#.\365d\304\240\355N\212\335\4\27h9\v\7\203e\377K@\36\34\3G\17B\327\266", 32) = 32
close(3)                                = 0
```
otherwise equivalent