### PR TITLE
Reject non-canonical Ed25519 public keys with y >= p (GH #1348)

### DIFF
--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -510,6 +510,15 @@ using CryptoPP::SHA512;
 // Bring in all the symbols from the 32-bit header
 using namespace CryptoPP::Donna::Arch32;
 
+/* Reject y >= p (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_pubkey_is_canonical(const byte pk[32]) {
+    if ((pk[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (pk[i] != 0xff) return true;
+    return pk[0] < 0xed;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -2038,7 +2047,8 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -2066,7 +2076,8 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -438,6 +438,15 @@ using CryptoPP::SHA512;
 // Bring in all the symbols from the 64-bit header
 using namespace CryptoPP::Donna::Arch64;
 
+/* Reject y >= p (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_pubkey_is_canonical(const byte pk[32]) {
+    if ((pk[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (pk[i] != 0xff) return true;
+    return pk[0] < 0xed;
+}
+
 /* out = in */
 inline void
 curve25519_copy(bignum25519 out, const bignum25519 in) {
@@ -1751,7 +1760,8 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -1779,7 +1789,8 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if ((RS[63] & 224) || !ed25519_pubkey_is_canonical(pk) ||
+        !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/validat9.cpp
+++ b/validat9.cpp
@@ -728,6 +728,63 @@ bool ValidateEd25519()
 	std::cout << (fail ? "FAILED    " : "passed    ");
 	std::cout << "verification check against test vector\n";
 
+	// Non-canonical public-key rejection (RFC 8032).
+	try {
+		// canonical y
+		const byte pk_id[32] = { 0x01 };
+		const byte pk_pminus1[32] = {
+			0xec,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		// non-canonical y: p, p+1, 2^255-1
+		const byte pk_p[32] = {
+			0xed,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		const byte pk_pplus1[32] = {
+			0xee,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+		const byte pk_top[32] = {
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+			0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x7f };
+
+		ed25519PublicKey k_id; k_id.SetPublicElement(pk_id);
+		ed25519PublicKey k_pminus1; k_pminus1.SetPublicElement(pk_pminus1);
+		ed25519PublicKey k_p; k_p.SetPublicElement(pk_p);
+		ed25519PublicKey k_pplus1; k_pplus1.SetPublicElement(pk_pplus1);
+		ed25519PublicKey k_top; k_top.SetPublicElement(pk_top);
+
+		const bool v_id = k_id.Validate(NullRNG(), 3);
+		const bool v_pminus1 = k_pminus1.Validate(NullRNG(), 3);
+		const bool v_p = k_p.Validate(NullRNG(), 3);
+		const bool v_pplus1 = k_pplus1.Validate(NullRNG(), 3);
+		const bool v_top = k_top.Validate(NullRNG(), 3);
+
+		// R = identity, S = 0 verifies against the identity key and any of its aliases.
+		byte sig[64] = { 0 };
+		sig[0] = 0x01;
+		const byte msg[] = { 't','e','s','t' };
+
+		ed25519Verifier ver_id(pk_id);
+		ed25519Verifier ver_p(pk_p);
+		ed25519Verifier ver_pplus1(pk_pplus1);
+		ed25519Verifier ver_top(pk_top);
+
+		const bool s_id = ver_id.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_p = ver_p.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_pplus1 = ver_pplus1.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+		const bool s_top = ver_top.VerifyMessage(msg, sizeof(msg), sig, sizeof(sig));
+
+		fail = !(v_id && v_pminus1 && !v_p && !v_pplus1 && !v_top &&
+		         s_id && !s_p && !s_pplus1 && !s_top);
+	}
+	catch (const Exception&) {
+		fail = true;
+	}
+
+	pass = pass && !fail;
+
+	std::cout << (fail ? "FAILED    " : "passed    ");
+	std::cout << "non-canonical public-key rejection\n";
+
 	return pass;
 }
 

--- a/xed25519.cpp
+++ b/xed25519.cpp
@@ -65,6 +65,15 @@ bool HasSmallOrder(const byte y[32])
     return (bool)((k >> 8) & 1);
 }
 
+// Reject y >= p (RFC 8032 canonical encoding check).
+bool IsCanonicalY(const byte y[32])
+{
+    if ((y[31] & 0x7f) != 0x7f) return true;
+    for (int i = 30; i >= 1; --i)
+        if (y[i] != 0xff) return true;
+    return y[0] < 0xed;
+}
+
 ANONYMOUS_NAMESPACE_END
 
 NAMESPACE_BEGIN(CryptoPP)
@@ -835,7 +844,7 @@ const Integer& ed25519PublicKey::GetPublicElement() const
 bool ed25519PublicKey::Validate(RandomNumberGenerator &rng, unsigned int level) const
 {
     CRYPTOPP_UNUSED(rng); CRYPTOPP_UNUSED(level);
-    return true;
+    return IsCanonicalY(m_pk);
 }
 
 ////////////////////////


### PR DESCRIPTION
 Fixes #1348.

  ## Problem

  `ed25519PublicKey::Validate()` returns true unconditionally, and the Donna verify path unpacks the encoded public key without rejecting `y >= p = 2^255 -
  19`. This lets multiple byte encodings decode to the same group element, as demonstrated by the PoC in the issue (canonical `y = 1` and non-canonical `y =
   p + 1` both verify against the same witness signature).

  ## Fix

  - `xed25519.cpp`: new `IsCanonicalY` helper; `Validate()` calls it and returns false for `y >= p`.
  - `donna_32.cpp`, `donna_64.cpp`: new `ed25519_pubkey_is_canonical` helper; `ge25519_unpack_negative_vartime` rejects non-canonical `y` before point
  recovery.
  - `validat9.cpp`: regression test covering canonical (`y = 1`, `y = p - 1`, accepted) and 
  non-canonical (`y = p`, `y = p + 1`, `y = 2^255 - 1`, rejected) using the witness signature from the PoC.

  ## Testing

  ```
  ./cryptest.exe v
  ```

  Validation passes locally on GCC 14 (Linux) and MinGW-w64 GCC 14 (Windows). `ValidateEd25519` shows:

  ```
  passed    non-canonical public-key rejection
  ```

  No other tests affected.

  ## Compatibility

  - API unchanged.
  - Keys produced by any compliant Ed25519 implementation are unaffected since a compliant encoder never emits `y >= p`.
  - Only crafted or malformed keys are newly rejected. A caller relying on `Validate()` always returning true will now see false
  for such keys.

  ## References

  - RFC 8032 section 5.1.3 (decoding Ed25519 public keys)
  - PoC and execution trace in #1348