### PR TITLE
Cap DERReencode recursion depth (GH #1353)

### DIFF
--- a/asn.cpp
+++ b/asn.cpp
@@ -268,8 +268,14 @@ size_t BERDecodeBitString(BufferedTransformation &bt, SecByteBlock &str, unsigne
 	return bc-1;
 }
 
-void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
+// Max nested constructed BER depth, matching OpenSSL ASN1_MAX_CONSTRUCTED_NEST.
+// See GH #1353.
+static const unsigned int DER_REENCODE_MAX_DEPTH = 32;
+
+static void DERReencodeLimited(BufferedTransformation &source, BufferedTransformation &dest, unsigned int depth)
 {
+	if (depth >= DER_REENCODE_MAX_DEPTH)
+		BERDecodeError();
 	byte tag;
 	source.Peek(tag);
 	BERGeneralDecoder decoder(source, tag);
@@ -279,10 +285,15 @@ void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
 	else
 	{
 		while (!decoder.EndReached())
-			DERReencode(decoder, encoder);
+			DERReencodeLimited(decoder, encoder, depth + 1);
 	}
 	decoder.MessageEnd();
 	encoder.MessageEnd();
+}
+
+void DERReencode(BufferedTransformation &source, BufferedTransformation &dest)
+{
+	DERReencodeLimited(source, dest, 0);
 }
 
 size_t BERDecodePeekLength(const BufferedTransformation &bt)


### PR DESCRIPTION
## Summary

  Fixes #1353.

  `DERReencode` walks nested constructed indefinite BER without a depth limit, so a crafted chain of `0x30 0x80` sequences can exhaust the thread stack. `PKCS8PrivateKey` import reaches this path via `BERDecodeOptionalAttributes`.

  The cap is 32 levels, matching OpenSSL `ASN1_MAX_CONSTRUCTED_NEST`. Deeper inputs throw `BERDecodeError` instead of recursing further.

  ## What changed

  - Added internal `DERReencodeLimited(source, dest, depth)` with the cap check at entry.
  - Kept public `DERReencode` as a depth-0 wrapper.