### PR TITLE
Reject Ed25519 signatures with S >= L (GH #1352)

### DIFF
--- a/donna_32.cpp
+++ b/donna_32.cpp
@@ -2028,6 +2028,22 @@ ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32]
     return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature);
 }
 
+/* Reject S >= L (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_scalar_is_canonical(const byte S[32]) {
+    static const byte L[32] = {
+        0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+        0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10
+    };
+    for (int i = 31; i >= 0; --i) {
+        if (S[i] < L[i]) return true;
+        if (S[i] > L[i]) return false;
+    }
+    return false;
+}
+
 int
 ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]) {
 
@@ -2038,7 +2054,7 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -2066,7 +2082,7 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/donna_64.cpp
+++ b/donna_64.cpp
@@ -1741,6 +1741,22 @@ ed25519_sign(const byte* message, size_t messageLength, const byte secretKey[32]
     return ed25519_sign_CXX(message, messageLength, secretKey, publicKey, signature);
 }
 
+/* Reject S >= L (RFC 8032 canonical encoding check). */
+inline bool
+ed25519_scalar_is_canonical(const byte S[32]) {
+    static const byte L[32] = {
+        0xed,0xd3,0xf5,0x5c,0x1a,0x63,0x12,0x58,
+        0xd6,0x9c,0xf7,0xa2,0xde,0xf9,0xde,0x14,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x10
+    };
+    for (int i = 31; i >= 0; --i) {
+        if (S[i] < L[i]) return true;
+        if (S[i] > L[i]) return false;
+    }
+    return false;
+}
+
 int
 ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte RS[64]) {
 
@@ -1751,7 +1767,7 @@ ed25519_sign_open_CXX(const byte *m, size_t mlen, const byte pk[32], const byte 
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */
@@ -1779,7 +1795,7 @@ ed25519_sign_open_CXX(std::istream& stream, const byte pk[32], const byte RS[64]
     bignum256modm hram, S;
     byte checkR[32];
 
-    if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
+    if (!ed25519_scalar_is_canonical(RS + 32) || !ge25519_unpack_negative_vartime(&A, pk))
         return -1;
 
     /* hram = H(R,A,m) */

--- a/tweetnacl.cpp
+++ b/tweetnacl.cpp
@@ -886,6 +886,17 @@ static int unpackneg(gf r[4],const byte p[32])
   return 0;
 }
 
+/* Reject S >= L per RFC 8032. See GH #1352. */
+static int scalar_is_canonical(const byte s[32])
+{
+  int i;
+  for(i=31; i>=0; --i) {
+    if (s[i] < L[i]) return 1;
+    if (s[i] > L[i]) return 0;
+  }
+  return 0;
+}
+
 int crypto_sign_open(byte *m,word64 *mlen,const byte *sm,word64 n,const byte *pk)
 {
   word32 i;
@@ -895,6 +906,7 @@ int crypto_sign_open(byte *m,word64 *mlen,const byte *sm,word64 n,const byte *pk
   *mlen = ~W64LIT(0);
   if (n < 64) return -1;
 
+  if (!scalar_is_canonical(sm + 32)) return -1;
   if (unpackneg(q,pk)) return -1;
 
   for(i=0; i<n; ++i) m[i] = sm[i];


### PR DESCRIPTION
## Summary

Addresses the signature-scalar part of GH #1352.

The Ed25519 verifier accepts non-canonical signatures where `S >= L` because the existing check only masks the top three bits of `S`, leaving the gap `L <= S < 2^253`. A valid signature changed from `S'` to `S' + L` still verifies because the equation holds modulo the subgroup order.

Both the Donna verifier and the NaCl C API verifier had this defect. Both are patched here in separate commits.

## What changed

- **Donna:** added `ed25519_scalar_is_canonical` to `donna_64.cpp` and `donna_32.cpp`, called at the start of both `ed25519_sign_open_CXX` overloads. The old `(RS[63] & 224)` top-bit mask was removed since the full order check covers it.
- **NaCl:** added `scalar_is_canonical` to `tweetnacl.cpp`, called in `crypto_sign_open` before `unpackneg`. Reused the existing `L` constant at file scope.