### PR TITLE
Fix CVE-2023-50981 in Rabin private key decoding

### DIFF
--- a/rabin.cpp
+++ b/rabin.cpp
@@ -132,8 +132,12 @@ void InvertibleRabinFunction::BERDecode(BufferedTransformation &bt)
 	m_u.BERDecode(seq);
 	seq.MessageEnd();
 
-	CRYPTOPP_ASSERT(IsPrime(m_p));
-	CRYPTOPP_ASSERT(IsPrime(m_q));
+	// Non-prime m_p or m_q loops indefinitely in CalculateInverse / ModularSquareRoot.
+	// Treat this as a decode failure, not a key-construction error.
+	if (!IsPrime(m_p))
+		BERDecodeError();
+	if (!IsPrime(m_q))
+		BERDecodeError();
 }
 
 void InvertibleRabinFunction::DEREncode(BufferedTransformation &bt) const


### PR DESCRIPTION
## Summary

Addresses the Rabin decode portion of CVE-2023-50981.

`InvertibleRabinFunction::BERDecode` checked `m_p` and `m_q` for primality with `CRYPTOPP_ASSERT`, which is compiled out in release builds. A non-prime `m_p` or `m_q` could then reach `CalculateInverse` and cause `ModularSquareRoot` to loop indefinitely.

This promotes the checks to runtime `BERDecodeError` throws at the decode boundary. `CalculateInverse` keeps its defensive asserts as a double-check.

## What changed

- Replaced the end-of-decode `CRYPTOPP_ASSERT(IsPrime(...))` checks in   `InvertibleRabinFunction::BERDecode` with runtime `BERDecodeError` checks.