### PR TITLE
Fix CVE-2023-50981 in ModularSquareRoot

### DIFF
--- a/nbtheory.cpp
+++ b/nbtheory.cpp
@@ -547,6 +547,10 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 	// Callers must ensure p is prime, GH #1249
 	CRYPTOPP_ASSERT(IsPrime(p));
 
+	// Cap loop iterations to bound work on a non-prime modulus.
+	// The cap is well beyond the expected count for normal prime moduli.
+	const unsigned int MAX_MODULAR_SQRT_ITERATIONS = 10000;
+
 	if (p%4 == 3)
 		return a_exp_b_mod_c(a, (p+1)/4, p);
 
@@ -559,8 +563,13 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 	}
 
 	Integer n=2;
+	unsigned int iters = 0;
 	while (Jacobi(n, p) != -1)
+	{
+		if (++iters > MAX_MODULAR_SQRT_ITERATIONS)
+			throw InvalidArgument("ModularSquareRoot: iteration cap exceeded");
 		++n;
+	}
 
 	Integer y = a_exp_b_mod_c(n, q, p);
 	Integer x = a_exp_b_mod_c(a, (q-1)/2, p);
@@ -568,8 +577,12 @@ Integer ModularSquareRoot(const Integer &a, const Integer &p)
 	x = a*x%p;
 	Integer tempb, t;
 
+	// Bound the outer Tonelli-Shanks loop.
+	unsigned int outerIters = 0;
 	while (b != 1)
 	{
+		if (++outerIters > MAX_MODULAR_SQRT_ITERATIONS)
+			throw InvalidArgument("ModularSquareRoot: iteration cap exceeded");
 		unsigned m=0;
 		tempb = b;
 		do


### PR DESCRIPTION
## Summary

Addresses the ModularSquareRoot part of CVE-2023-50981.

`ModularSquareRoot` uses Tonelli-Shanks, which expects a prime modulus. The non-residue search loop was unbounded, and the outer Tonelli-Shanks loop also relied on that prime-modulus assumption. In release builds, `CRYPTOPP_ASSERT(IsPrime(p))` is compiled out, so a non-prime `p` could make the function run indefinitely.

This complements #1255. That PR checks `p` at function entry. This PR adds iteration caps as a defensive backstop, so the function cannot do unbounded work if a non-prime modulus still reaches it.

## What changed

- Added a `MAX_MODULAR_SQRT_ITERATIONS` cap in `ModularSquareRoot`
- Applied the cap to the non-residue search loop
- Applied the cap to the outer Tonelli-Shanks loop
- Throws `InvalidArgument` if the cap is exceeded