### PR TITLE
Use two-argument static_assert in CRYPTOPP_COMPILE_ASSERT

### DIFF
--- a/misc.h
+++ b/misc.h
@@ -152,7 +152,7 @@ class Integer;
 ///  a negative-sized array triggers the assert at compile time.
 # define CRYPTOPP_COMPILE_ASSERT(expr) { ... }
 #elif defined(CRYPTOPP_CXX17_STATIC_ASSERT)
-# define CRYPTOPP_COMPILE_ASSERT(expr) static_assert(expr)
+# define CRYPTOPP_COMPILE_ASSERT(expr) static_assert(expr, #expr)
 #else // CRYPTOPP_DOXYGEN_PROCESSING
 template <bool b>
 struct CompileAssert


### PR DESCRIPTION
## Summary

`CRYPTOPP_COMPILE_ASSERT` expanded to `static_assert(expr)`, which is the single-argument C++17 form. This can warn under `-Wc++17-extensions` when code is compiled as C++14.

Using `static_assert(expr, #expr)` keeps the macro compatible with C++11 and C++14. The stringified expression also gives a useful message when the assert fails.

## What changed

- Updated `CRYPTOPP_COMPILE_ASSERT` in `misc.h` to use `static_assert(expr, #expr)`.