### PR TITLE
Reject zero-length AEAD authentication tags (GH #1364)

### DIFF
--- a/authenc.cpp
+++ b/authenc.cpp
@@ -140,6 +140,10 @@ reswitch:
 
 void AuthenticatedSymmetricCipherBase::TruncatedFinal(byte *mac, size_t macSize)
 {
+	// https://github.com/weidai11/cryptopp/issues/1364
+	if (macSize == 0)
+		throw InvalidArgument(AlgorithmName() + ": zero-length authentication tags are not allowed");
+
 	// https://github.com/weidai11/cryptopp/issues/954
 	this->ThrowIfInvalidTruncatedSize(macSize);
 


### PR DESCRIPTION
Fixes #1364.

GCM, EAX, CCM, ChaCha20-Poly1305, and XChaCha20-Poly1305 accepted zero-length authentication tags through the one-shot APIs and authenticated filters. `EncryptAndAuthenticate` produced no tag, and `DecryptAndVerify` could report tampered ciphertext as authentic. Reject a zero tag size in `AuthenticatedSymmetricCipherBase::TruncatedFinal`, which every affected path reaches during finalisation.

The one-shot APIs process the message before finalisation, so output buffers may already contain data when the exception is thrown. Callers must discard that output.

The reporter's reproducer finds both affected cases before this change and none after it. Valid-tag controls still pass.